### PR TITLE
Set a default pvc request size

### DIFF
--- a/testdata/TestConvert/volumes/k8s.yaml
+++ b/testdata/TestConvert/volumes/k8s.yaml
@@ -119,7 +119,9 @@ metadata:
 spec:
   accessModes:
   - ReadWriteOnce
-  resources: {}
+  resources:
+    requests:
+      storage: 100Mi
 status: {}
 
 ---

--- a/volumes.go
+++ b/volumes.go
@@ -52,7 +52,10 @@ func (t Transformer) processVolumes(project *types.Project, resources *Resources
 			delete(volume.Labels, VolumeStorageClassNameLabelKey)
 		}
 
-		var requests corev1.ResourceList
+		requests := corev1.ResourceList{
+			// default to 100Mi if not specified (same as kompose)
+			corev1.ResourceStorage: resource.MustParse("100Mi"),
+		}
 		if size, ok := volume.Labels[VolumeSizeLabelKey]; ok {
 			quantity, err := resource.ParseQuantity(size)
 			if err != nil {


### PR DESCRIPTION
Based on kompose default, to avoid issues on `kubectl apply`