### PR TITLE
Add mapping from Docker extra_hosts to Kubernetes hostAliases

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -94,6 +94,10 @@ func TestConvert(t *testing.T) {
 			Files:    []string{"testdata/probes/compose.yaml"},
 			Profiles: []string{"*"},
 		}, DryRun: TestRunKubectlDryRun | TestRunComposeDryRun},
+		{Name: "extra-hosts/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/extra-hosts/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun | TestRunComposeDryRun},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/testdata/TestConvert/extra-hosts/k8s.yaml
+++ b/testdata/TestConvert/extra-hosts/k8s.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: web
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: IfNotPresent
+        name: web
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources: {}
+      hostAliases:
+      - hostnames:
+        - database.local
+        ip: 192.168.1.10
+      - hostnames:
+        - cache.local
+        ip: 192.168.1.20
+      - hostnames:
+        - api.local
+        - backup.local
+        ip: 192.168.1.30
+      restartPolicy: Always
+status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app.kubernetes.io/name: web
+status:
+  loadBalancer: {}

--- a/testdata/extra-hosts/compose.yaml
+++ b/testdata/extra-hosts/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  web:
+    image: nginx
+    extra_hosts:
+      - "database.local:192.168.1.10"
+      - "cache.local:192.168.1.20"
+      - "api.local:192.168.1.30"
+      - "backup.local:192.168.1.30"
+    ports:
+      - "8080:80"


### PR DESCRIPTION
Implements conversion of Docker Compose's extra_hosts configuration to
Kubernetes hostAliases in PodSpec. This allows users to define custom
host-to-IP mappings that will be added to /etc/hosts in pods.

The conversion groups multiple hostnames pointing to the same IP address
into a single HostAlias entry, with deterministic ordering (sorted by IP
and hostname) for consistent output.

Changes:
- Add convertExtraHosts() function to transform HostsList to []HostAlias
- Update createPodSpec() to include hostAliases field
- Add test case with extra_hosts configuration