### PR TITLE
Add support for image type volumes (issue #49)

### DIFF
--- a/testdata/TestConvert/volumes/k8s.yaml
+++ b/testdata/TestConvert/volumes/k8s.yaml
@@ -88,6 +88,9 @@ spec:
           name: postgres-cee76ffa
           readOnly: true
           subPath: init.sql
+        - mountPath: /image-data
+          name: image-busybox-latest
+          readOnly: true
       restartPolicy: Always
       volumes:
       - emptyDir:
@@ -102,6 +105,10 @@ spec:
       - configMap:
           name: postgres-cee76ffa
         name: postgres-cee76ffa
+      - image:
+          pullPolicy: Always
+          reference: busybox:latest
+        name: image-busybox-latest
 status: {}
 
 ---

--- a/testdata/volumes/compose.yaml
+++ b/testdata/volumes/compose.yaml
@@ -37,6 +37,9 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+      - type: image
+        source: busybox:latest
+        target: /image-data
     tmpfs:
       - /tmpx
       - /runx

--- a/volumes.go
+++ b/volumes.go
@@ -258,8 +258,8 @@ func (t Transformer) updatePodSpecWithVolumes(spec *corev1.PodSpec, service type
 						Name: volumeName,
 						VolumeSource: corev1.VolumeSource{
 							Image: &corev1.ImageVolumeSource{
-								Reference: mapping.ImageRef,
-								PullPolicy: &pullPolicy,
+								Reference:  mapping.ImageRef,
+								PullPolicy: pullPolicy,
 							},
 						},
 					}

--- a/volumes.go
+++ b/volumes.go
@@ -301,10 +301,13 @@ func (t Transformer) updatePodSpecWithVolumes(spec *corev1.PodSpec, service type
 			} else if mapping.IsImage {
 				// Image volumes are always read-only
 				volumeMount = corev1.VolumeMount{
-					Name:        volumeName,
-					MountPath:   serviceVolume.Target,
-					ReadOnly:    true,
-					SubPathExpr: serviceVolume.Volume.Subpath,
+					Name:      volumeName,
+					MountPath: serviceVolume.Target,
+					ReadOnly:  true,
+				}
+				// Only set SubPathExpr if Volume is not nil
+				if serviceVolume.Volume != nil {
+					volumeMount.SubPathExpr = serviceVolume.Volume.Subpath
 				}
 			} else if serviceVolume.Type == "volume" {
 				volumeMount = corev1.VolumeMount{


### PR DESCRIPTION
This implements support for Kubernetes image volumes, which allow
mounting OCI images/artifacts as read-only volumes in pods.

Changes:
- Extended VolumeMapping struct with ImageRef, PullPolicy, and IsImage fields
- Added handling for type: image volumes in Docker Compose files
- Volumes with type: image are converted to Kubernetes Image volume sources
- Pull policy defaults to "Always" for :latest tags, "IfNotPresent" otherwise
- Image volumes are always mounted as read-only (per Kubernetes spec)
- Added test case with busybox:latest image volume

The feature requires Kubernetes v1.33+ (beta) with appropriate container
runtime support (CRI-O v1.31+ or containerd v2.1.0+).

fixes #49