### PR TITLE
Fix hostpath volumes to respect read-write flag

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -98,6 +98,10 @@ func TestConvert(t *testing.T) {
 			Files:    []string{"testdata/extra-hosts/compose.yaml"},
 			Profiles: []string{"*"},
 		}, DryRun: TestRunKubectlDryRun | TestRunComposeDryRun},
+		{Name: "hostpath/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/hostpath/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun | TestRunComposeDryRun},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/testdata/TestConvert/collector/a/k8s.yaml
+++ b/testdata/TestConvert/collector/a/k8s.yaml
@@ -86,7 +86,7 @@ spec:
           subPath: config.yaml
         - mountPath: /var/log/pods
           name: pod-logs
-          readOnly: true
+          readOnly: false
       restartPolicy: Always
       serviceAccountName: otelcontribcol
       volumes:

--- a/testdata/TestConvert/collector/a/k8s.yaml
+++ b/testdata/TestConvert/collector/a/k8s.yaml
@@ -86,7 +86,6 @@ spec:
           subPath: config.yaml
         - mountPath: /var/log/pods
           name: pod-logs
-          readOnly: false
       restartPolicy: Always
       serviceAccountName: otelcontribcol
       volumes:

--- a/testdata/TestConvert/collector/b/k8s.yaml
+++ b/testdata/TestConvert/collector/b/k8s.yaml
@@ -80,7 +80,7 @@ spec:
           subPath: config.yaml
         - mountPath: /var/log/pods
           name: pod-logs
-          readOnly: true
+          readOnly: false
       restartPolicy: Always
       serviceAccountName: otelcontribcol
       volumes:

--- a/testdata/TestConvert/collector/b/k8s.yaml
+++ b/testdata/TestConvert/collector/b/k8s.yaml
@@ -80,7 +80,6 @@ spec:
           subPath: config.yaml
         - mountPath: /var/log/pods
           name: pod-logs
-          readOnly: false
       restartPolicy: Always
       serviceAccountName: otelcontribcol
       volumes:

--- a/testdata/TestConvert/hostpath/k8s.yaml
+++ b/testdata/TestConvert/hostpath/k8s.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test
+    spec:
+      containers:
+      - image: busybox
+        imagePullPolicy: IfNotPresent
+        name: test
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/tmp
+          name: logs-default
+          readOnly: false
+        - mountPath: /var/log
+          name: logs-ro
+          readOnly: true
+        - mountPath: /var/data
+          name: logs-rw
+          readOnly: false
+      restartPolicy: Always
+      volumes:
+      - hostPath:
+          path: /host/tmp
+        name: logs-default
+      - hostPath:
+          path: /host/logs
+        name: logs-ro
+      - hostPath:
+          path: /host/data
+        name: logs-rw
+status: {}

--- a/testdata/TestConvert/hostpath/k8s.yaml
+++ b/testdata/TestConvert/hostpath/k8s.yaml
@@ -18,24 +18,22 @@ spec:
         name: test
         resources: {}
         volumeMounts:
-        - mountPath: /var/tmp
-          name: logs-default
-          readOnly: false
         - mountPath: /var/log
           name: logs-ro
           readOnly: true
         - mountPath: /var/data
           name: logs-rw
-          readOnly: false
+        - mountPath: /var/tmp
+          name: logs-default
       restartPolicy: Always
       volumes:
-      - hostPath:
-          path: /host/tmp
-        name: logs-default
       - hostPath:
           path: /host/logs
         name: logs-ro
       - hostPath:
           path: /host/data
         name: logs-rw
+      - hostPath:
+          path: /host/tmp
+        name: logs-default
 status: {}

--- a/testdata/hostpath/compose.yaml
+++ b/testdata/hostpath/compose.yaml
@@ -1,0 +1,18 @@
+services:
+  test:
+    image: busybox
+    volumes:
+      - logs-ro:/var/log:ro
+      - logs-rw:/var/data:rw
+      - logs-default:/var/tmp
+
+volumes:
+  logs-ro:
+    labels:
+      - kubepose.volume.hostPath=/host/logs
+  logs-rw:
+    labels:
+      - kubepose.volume.hostPath=/host/data
+  logs-default:
+    labels:
+      - kubepose.volume.hostPath=/host/tmp

--- a/volumes.go
+++ b/volumes.go
@@ -296,7 +296,7 @@ func (t Transformer) updatePodSpecWithVolumes(spec *corev1.PodSpec, service type
 				volumeMount = corev1.VolumeMount{
 					Name:      volumeName,
 					MountPath: serviceVolume.Target,
-					ReadOnly:  true,
+					ReadOnly:  serviceVolume.ReadOnly,
 				}
 			} else if mapping.IsImage {
 				// Image volumes are always read-only


### PR DESCRIPTION
Fixes #88

Previously, hostpath volumes were hardcoded to be read-only regardless of the Docker Compose volume configuration. This change makes hostpath volumes respect the serviceVolume.ReadOnly flag from the Docker Compose configuration, allowing them to be mounted as read-write when specified with :rw in the volume mapping.

The fix aligns hostpath volume behavior with regular PersistentVolume handling, which already respects the ReadOnly flag correctly.