### PR TITLE
Fix ConfigMap key mismatch for file-based configs

### DIFF
--- a/configs.go
+++ b/configs.go
@@ -16,6 +16,7 @@ import (
 
 type ConfigMapping struct {
 	Name     string
+	Key      string
 	External bool
 }
 
@@ -61,7 +62,7 @@ func (t Transformer) processConfigs(project *types.Project, resources *Resources
 		}
 
 		k8sConfigName := fmt.Sprintf("%s-%s", name, shortHash)
-		configMapping[name] = ConfigMapping{Name: k8sConfigName}
+		configMapping[name] = ConfigMapping{Name: k8sConfigName, Key: filename}
 
 		k8sConfigMap := corev1.ConfigMap{
 			TypeMeta: metav1.TypeMeta{
@@ -133,7 +134,7 @@ func (t Transformer) updatePodSpecWithConfigs(spec *corev1.PodSpec, service type
 					// For non-external configs, mount only the specific key
 					volume.VolumeSource.ConfigMap.Items = []corev1.KeyToPath{
 						{
-							Key:  configDefaultKey,
+							Key:  mapping.Key,
 							Path: filepath.Base(target),
 						},
 					}

--- a/testdata/TestConvert/configs/k8s.yaml
+++ b/testdata/TestConvert/configs/k8s.yaml
@@ -78,7 +78,7 @@ spec:
         name: my_config
       - configMap:
           items:
-          - key: content
+          - key: config.json
             path: file_config
           name: file_config-123b70c3
         name: file_config


### PR DESCRIPTION
When configs are defined from files in Docker Compose, the ConfigMap is created with the filename as the key (e.g., "config.json"), but the Deployment was always referencing "content" as the key. This caused pods to fail with "configmap references non-existent config key" errors.

Changes:
- Added Key field to ConfigMapping struct to track the actual key used
- Set the Key field when processing configs (using filename variable)
- Use mapping.Key instead of hardcoded configDefaultKey in volume mounts

Fixes #89