### PR TITLE
Add negative tests and replace healthcheck panic with validation

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -51,6 +51,12 @@ type Transformer struct {
 }
 
 func (t Transformer) Convert(project *types.Project) (*Resources, error) {
+	for _, name := range project.ServiceNames() {
+		if err := validateService(project.Services[name]); err != nil {
+			return nil, fmt.Errorf("service %q: %w", name, err)
+		}
+	}
+
 	resources := &Resources{}
 
 	secretMappings, err := t.processSecrets(project, resources)
@@ -182,6 +188,20 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 	}
 
 	return resources, nil
+}
+
+// validateService rejects service configurations that the converter cannot
+// faithfully translate. Failing fast here keeps the rest of the conversion
+// pipeline panic-free.
+func validateService(service types.ServiceConfig) error {
+	if service.HealthCheck != nil && len(service.HealthCheck.Test) > 0 {
+		switch service.HealthCheck.Test[0] {
+		case "CMD-SHELL", "CMD", "NONE":
+		default:
+			return fmt.Errorf("unsupported healthcheck test type %q (expected CMD, CMD-SHELL, or NONE)", service.HealthCheck.Test[0])
+		}
+	}
+	return nil
 }
 
 func (t Transformer) addContainersToSpec(podSpec *corev1.PodSpec, appServices, initServices []types.ServiceConfig) {
@@ -692,7 +712,9 @@ func getProbes(service types.ServiceConfig) (liveness *corev1.Probe, readiness *
 		case "NONE":
 			return nil, nil, nil
 		default:
-			panic("unsupported health check type: " + service.HealthCheck.Test[0])
+			// Unsupported types are rejected upfront by validateService;
+			// fall through here defensively so callers never panic.
+			return nil, nil, nil
 		}
 
 		probe = &corev1.Probe{

--- a/convert_negative_test.go
+++ b/convert_negative_test.go
@@ -1,0 +1,248 @@
+package kubepose_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	"github.com/middle-management/kubepose"
+)
+
+// TestConvertNegative covers invalid or edge-case service configurations.
+// Some scenarios assert desired error behavior; others document current
+// silent-fallback behavior so that regressions or future hardening work
+// surface here first.
+func TestConvertNegative(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unknown healthcheck test type returns error not panic", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			HealthCheck: &types.HealthCheckConfig{
+				Test: []string{"WHATEVER", "echo", "hi"},
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil {
+			t.Fatal("expected error for unknown healthcheck test type, got nil")
+		}
+		if !strings.Contains(err.Error(), "unsupported healthcheck test type") {
+			t.Fatalf("expected unsupported-healthcheck error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), `"web"`) {
+			t.Fatalf("expected error to mention service name, got: %v", err)
+		}
+	})
+
+	t.Run("error from one service surfaces deterministically", func(t *testing.T) {
+		t.Parallel()
+		// Two services, one valid and one invalid. The invalid one should
+		// be reported with its name; iteration order must be deterministic.
+		project := &types.Project{
+			Services: types.Services{
+				"a-good": types.ServiceConfig{Name: "a-good", Image: "nginx"},
+				"z-bad": types.ServiceConfig{
+					Name:  "z-bad",
+					Image: "nginx",
+					HealthCheck: &types.HealthCheckConfig{
+						Test: []string{"BOGUS"},
+					},
+				},
+			},
+		}
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil {
+			t.Fatal("expected error from invalid service, got nil")
+		}
+		if !strings.Contains(err.Error(), `"z-bad"`) {
+			t.Fatalf("expected error to mention z-bad, got: %v", err)
+		}
+	})
+
+	t.Run("healthcheck NONE disables probes", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			HealthCheck: &types.HealthCheckConfig{
+				Test: []string{"NONE"},
+			},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resources.Deployments) != 1 {
+			t.Fatalf("expected 1 deployment, got %d", len(resources.Deployments))
+		}
+		c := resources.Deployments[0].Spec.Template.Spec.Containers[0]
+		if c.LivenessProbe != nil || c.ReadinessProbe != nil || c.StartupProbe != nil {
+			t.Fatal("expected no probes when healthcheck test is NONE")
+		}
+	})
+
+	t.Run("healthcheck disable=true produces no probes", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			HealthCheck: &types.HealthCheckConfig{
+				Test:    []string{"CMD", "/healthz"},
+				Disable: true,
+			},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		c := resources.Deployments[0].Spec.Template.Spec.Containers[0]
+		if c.LivenessProbe != nil || c.ReadinessProbe != nil || c.StartupProbe != nil {
+			t.Fatal("expected no probes when healthcheck is disabled")
+		}
+	})
+
+	t.Run("invalid published port is silently ignored", func(t *testing.T) {
+		t.Parallel()
+		// Documents existing behavior at convert.go convertServicePorts.
+		// strconv errors are swallowed; published falls back to 0.
+		// TODO: surface a real error in a future PR.
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			Ports: []types.ServicePortConfig{
+				{Target: 80, Published: "not-a-number"},
+			},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resources.Services) != 1 {
+			t.Fatalf("expected 1 service, got %d", len(resources.Services))
+		}
+		ports := resources.Services[0].Spec.Ports
+		if len(ports) != 1 || ports[0].Port != 0 {
+			t.Fatalf("expected silent fallback to port 0, got %+v", ports)
+		}
+	})
+
+	t.Run("invalid healthcheck port annotation is silently ignored", func(t *testing.T) {
+		t.Parallel()
+		// Documents existing behavior at convert.go getProbes.
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			Ports: []types.ServicePortConfig{{Target: 8080, Protocol: "tcp"}},
+			Annotations: map[string]string{
+				kubepose.HealthcheckHttpGetPathAnnotationKey: "/healthz",
+				kubepose.HealthcheckHttpGetPortAnnotationKey: "not-a-port",
+			},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		c := resources.Deployments[0].Spec.Template.Spec.Containers[0]
+		if c.LivenessProbe == nil || c.LivenessProbe.HTTPGet == nil {
+			t.Fatal("expected an HTTP liveness probe")
+		}
+		// Falls back to first declared port instead of erroring.
+		if got := c.LivenessProbe.HTTPGet.Port.IntVal; got != 8080 {
+			t.Fatalf("expected fallback to first port 8080, got %d", got)
+		}
+	})
+
+	t.Run("invalid selector matchLabels JSON falls back to default", func(t *testing.T) {
+		t.Parallel()
+		// Documents convert.go getMatchLabels: bad JSON is logged as a
+		// warning and the default app selector is used instead.
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			Annotations: map[string]string{
+				kubepose.SelectorMatchLabelsAnnotationKey: "{not valid json",
+			},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		got := resources.Deployments[0].Spec.Selector.MatchLabels
+		want := map[string]string{kubepose.AppSelectorLabelKey: "web"}
+		if len(got) != len(want) || got[kubepose.AppSelectorLabelKey] != "web" {
+			t.Fatalf("expected fallback selector %v, got %v", want, got)
+		}
+	})
+
+	t.Run("named user is skipped with no security context", func(t *testing.T) {
+		t.Parallel()
+		// Documents that named users like "ubuntu" are dropped (only numeric
+		// IDs are supported); a warning is printed but conversion succeeds.
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			User:  "ubuntu",
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		spec := resources.Deployments[0].Spec.Template.Spec
+		if spec.SecurityContext != nil {
+			t.Fatalf("expected no SecurityContext for non-numeric user, got %+v", spec.SecurityContext)
+		}
+	})
+
+	t.Run("numeric user populates SecurityContext", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			User:  "1000:2000",
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		sc := resources.Deployments[0].Spec.Template.Spec.SecurityContext
+		if sc == nil || sc.RunAsUser == nil || *sc.RunAsUser != 1000 {
+			t.Fatalf("expected RunAsUser=1000, got %+v", sc)
+		}
+		if sc.RunAsGroup == nil || *sc.RunAsGroup != 2000 {
+			t.Fatalf("expected RunAsGroup=2000, got %+v", sc)
+		}
+	})
+
+	t.Run("CMD with empty command list still produces a probe", func(t *testing.T) {
+		t.Parallel()
+		// Documents current behavior: ["CMD"] with no following args
+		// yields an exec probe with an empty Command slice (kubectl would
+		// reject this on apply). A future PR could reject this upfront.
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			HealthCheck: &types.HealthCheckConfig{
+				Test: []string{"CMD"},
+			},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		c := resources.Deployments[0].Spec.Template.Spec.Containers[0]
+		if c.LivenessProbe == nil || c.LivenessProbe.Exec == nil {
+			t.Fatal("expected an exec liveness probe")
+		}
+		if len(c.LivenessProbe.Exec.Command) != 0 {
+			t.Fatalf("expected empty Command, got %v", c.LivenessProbe.Exec.Command)
+		}
+	})
+}
+
+func projectWith(svc types.ServiceConfig) *types.Project {
+	return &types.Project{
+		Services: types.Services{svc.Name: svc},
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `TestConvertNegative` covering invalid/edge-case service configs: unknown healthcheck test types, NONE/disabled healthchecks, malformed published ports, malformed healthcheck port annotations, invalid selector matchLabels JSON, named user IDs.
- Replaces the panic in `getProbes` for unsupported healthcheck test types with an upfront `validateService` check in `Convert` that returns a clear `service "X": unsupported healthcheck test type` error. The default branch in `getProbes` now falls through defensively so the converter never panics on bad input.
- Several tests pin current silent-fallback behavior (bad strconv values, invalid selector JSON) so future hardening will surface here first.

## Test plan
- [ ] `go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)