### PR TITLE
Add StatefulSet, CronJob, and HorizontalPodAutoscaler support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ The tests in the `testdata` directory are integration tests which also work as e
 | Multi-Container Pods | ✅ | Group via `kubepose.service.group` |
 | Init Containers | ✅ | Mark with `kubepose.container.type: init` |
 | Sidecar Containers | ✅ | Init containers with `restart: always` |
-| StatefulSets | 🚧 | Planned |
-| CronJobs | 🚧 | Planned |
+| StatefulSets | ✅ | Enable with `kubepose.workload: StatefulSet` |
+| CronJobs | ✅ | Enable with `kubepose.cronjob.schedule: "<cron>"` |
+| HorizontalPodAutoscaler | ✅ | Enable with `kubepose.hpa.{minReplicas,maxReplicas,targetCPUUtilization}` |
 
 ### Container Configuration
 

--- a/annotations.go
+++ b/annotations.go
@@ -12,13 +12,29 @@ const (
 	HealthcheckHttpGetPathAnnotationKey        = "kubepose.healthcheck.httpGet.path"
 	HealthcheckHttpGetPortAnnotationKey        = "kubepose.healthcheck.httpGet.port"
 	ContainerTypeAnnotationKey                 = "kubepose.container.type"
-	ConfigHmacKeyAnnotationKey                 = "kubepose.config.hmacKey"
-	SecretHmacKeyAnnotationKey                 = "kubepose.secret.hmacKey"
-	VolumeHmacKeyAnnotationKey                 = "kubepose.volume.hmacKey"
-	VolumeHostPathLabelKey                     = "kubepose.volume.hostPath"
-	VolumeStorageClassNameLabelKey             = "kubepose.volume.storageClassName"
-	VolumeSizeLabelKey                         = "kubepose.volume.size"
-	SecretSubPathLabelKey                      = "kubepose.secret.subPath"
+
+	// WorkloadTypeAnnotationKey selects the kubernetes workload kind.
+	// Allowed values: "Deployment" (default), "StatefulSet". DaemonSets
+	// are still selected by deploy.mode=global; CronJobs by setting the
+	// CronJobScheduleAnnotationKey.
+	WorkloadTypeAnnotationKey = "kubepose.workload"
+
+	// CronJobScheduleAnnotationKey, when set on a service, emits a CronJob
+	// using the value as the cron schedule (e.g. "0 * * * *").
+	CronJobScheduleAnnotationKey = "kubepose.cronjob.schedule"
+
+	// HPA annotations. Setting either Min or Max enables HPA generation
+	// alongside the workload (Deployment or StatefulSet).
+	HPAMinReplicasAnnotationKey          = "kubepose.hpa.minReplicas"
+	HPAMaxReplicasAnnotationKey          = "kubepose.hpa.maxReplicas"
+	HPATargetCPUUtilizationAnnotationKey = "kubepose.hpa.targetCPUUtilization"
+	ConfigHmacKeyAnnotationKey           = "kubepose.config.hmacKey"
+	SecretHmacKeyAnnotationKey           = "kubepose.secret.hmacKey"
+	VolumeHmacKeyAnnotationKey           = "kubepose.volume.hmacKey"
+	VolumeHostPathLabelKey               = "kubepose.volume.hostPath"
+	VolumeStorageClassNameLabelKey       = "kubepose.volume.storageClassName"
+	VolumeSizeLabelKey                   = "kubepose.volume.size"
+	SecretSubPathLabelKey                = "kubepose.secret.subPath"
 )
 
 // HMAC keys allow invalidation if the shape of an immutable

--- a/convert.go
+++ b/convert.go
@@ -106,26 +106,22 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 		})
 
 		for _, service := range appServices {
-			if service.Deploy != nil && service.Deploy.Mode == "global" {
-				ds := t.createDaemonSet(resources, service)
-				t.addContainersToSpec(&ds.Spec.Template.Spec, appServices, initServices)
-				for _, svc := range append(appServices, initServices...) {
-					t.updatePodSpecWithSecrets(&ds.Spec.Template.Spec, svc, secretMappings)
-					t.updatePodSpecWithConfigs(&ds.Spec.Template.Spec, svc, configMappings)
-					t.updatePodSpecWithVolumes(&ds.Spec.Template.Spec, svc, volumeMappings, resources)
+			podSpec, kind := t.dispatchWorkload(resources, service)
+			t.addContainersToSpec(podSpec, appServices, initServices)
+			for _, svc := range append(appServices, initServices...) {
+				t.updatePodSpecWithSecrets(podSpec, svc, secretMappings)
+				t.updatePodSpecWithConfigs(podSpec, svc, configMappings)
+				t.updatePodSpecWithVolumes(podSpec, svc, volumeMappings, resources)
+			}
+			removeDuplicateVolumeMounts(podSpec.Containers)
+			removeDuplicateVolumeMounts(podSpec.InitContainers)
+
+			if hasHPA(service) {
+				hpa, err := t.createHorizontalPodAutoscaler(service, kind)
+				if err != nil {
+					return nil, fmt.Errorf("service %q: %w", service.Name, err)
 				}
-				removeDuplicateVolumeMounts(ds.Spec.Template.Spec.Containers)
-				removeDuplicateVolumeMounts(ds.Spec.Template.Spec.InitContainers)
-			} else {
-				deploy := t.createDeployment(resources, service)
-				t.addContainersToSpec(&deploy.Spec.Template.Spec, appServices, initServices)
-				for _, svc := range append(appServices, initServices...) {
-					t.updatePodSpecWithSecrets(&deploy.Spec.Template.Spec, svc, secretMappings)
-					t.updatePodSpecWithConfigs(&deploy.Spec.Template.Spec, svc, configMappings)
-					t.updatePodSpecWithVolumes(&deploy.Spec.Template.Spec, svc, volumeMappings, resources)
-				}
-				removeDuplicateVolumeMounts(deploy.Spec.Template.Spec.Containers)
-				removeDuplicateVolumeMounts(deploy.Spec.Template.Spec.InitContainers)
+				resources.HorizontalPodAutoscalers = append(resources.HorizontalPodAutoscalers, hpa)
 			}
 
 			if len(service.Ports) > 0 {
@@ -165,7 +161,45 @@ func validateService(service types.ServiceConfig) error {
 			return fmt.Errorf("unsupported healthcheck test type %q (expected CMD, CMD-SHELL, or NONE)", service.HealthCheck.Test[0])
 		}
 	}
+	if w, ok := service.Annotations[WorkloadTypeAnnotationKey]; ok {
+		switch w {
+		case "Deployment", "StatefulSet":
+		default:
+			return fmt.Errorf("unsupported %s %q (expected Deployment or StatefulSet)", WorkloadTypeAnnotationKey, w)
+		}
+	}
+	if schedule, ok := service.Annotations[CronJobScheduleAnnotationKey]; ok {
+		if schedule == "" {
+			return fmt.Errorf("%s must not be empty", CronJobScheduleAnnotationKey)
+		}
+		if hasHPA(service) {
+			return fmt.Errorf("HPA annotations are incompatible with %s", CronJobScheduleAnnotationKey)
+		}
+		if _, ok := service.Annotations[WorkloadTypeAnnotationKey]; ok {
+			return fmt.Errorf("%s and %s are mutually exclusive", CronJobScheduleAnnotationKey, WorkloadTypeAnnotationKey)
+		}
+	}
 	return nil
+}
+
+// dispatchWorkload creates the appropriate workload object for the service
+// (CronJob, StatefulSet, DaemonSet, or Deployment) and returns a pointer to
+// its inner pod spec along with the workload kind for HPA target refs.
+func (t Transformer) dispatchWorkload(resources *Resources, service types.ServiceConfig) (*corev1.PodSpec, string) {
+	if _, ok := service.Annotations[CronJobScheduleAnnotationKey]; ok {
+		c := t.createCronJob(resources, service)
+		return &c.Spec.JobTemplate.Spec.Template.Spec, "CronJob"
+	}
+	if service.Annotations[WorkloadTypeAnnotationKey] == "StatefulSet" {
+		s := t.createStatefulSet(resources, service)
+		return &s.Spec.Template.Spec, "StatefulSet"
+	}
+	if service.Deploy != nil && service.Deploy.Mode == "global" {
+		ds := t.createDaemonSet(resources, service)
+		return &ds.Spec.Template.Spec, "DaemonSet"
+	}
+	deploy := t.createDeployment(resources, service)
+	return &deploy.Spec.Template.Spec, "Deployment"
 }
 
 // getServiceName returns the kubernetes resource name for a compose service:

--- a/convert_negative_test.go
+++ b/convert_negative_test.go
@@ -215,6 +215,121 @@ func TestConvertNegative(t *testing.T) {
 		}
 	})
 
+	t.Run("unknown workload type returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "web",
+			Image: "nginx",
+			Annotations: map[string]string{
+				kubepose.WorkloadTypeAnnotationKey: "ReplicaSet",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "unsupported kubepose.workload") {
+			t.Fatalf("expected unsupported workload error, got: %v", err)
+		}
+	})
+
+	t.Run("empty cronjob schedule returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "job",
+			Image: "alpine",
+			Annotations: map[string]string{
+				kubepose.CronJobScheduleAnnotationKey: "",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "must not be empty") {
+			t.Fatalf("expected empty-schedule error, got: %v", err)
+		}
+	})
+
+	t.Run("hpa on cronjob is rejected", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "job",
+			Image: "alpine",
+			Annotations: map[string]string{
+				kubepose.CronJobScheduleAnnotationKey: "0 * * * *",
+				kubepose.HPAMaxReplicasAnnotationKey:  "5",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "incompatible") {
+			t.Fatalf("expected HPA-on-CronJob error, got: %v", err)
+		}
+	})
+
+	t.Run("hpa without max replicas returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "api",
+			Image: "nginx",
+			Annotations: map[string]string{
+				kubepose.HPAMinReplicasAnnotationKey: "2",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "maxReplicas") {
+			t.Fatalf("expected missing-maxReplicas error, got: %v", err)
+		}
+	})
+
+	t.Run("hpa min greater than max returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "api",
+			Image: "nginx",
+			Annotations: map[string]string{
+				kubepose.HPAMinReplicasAnnotationKey: "10",
+				kubepose.HPAMaxReplicasAnnotationKey: "2",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "greater than maxReplicas") {
+			t.Fatalf("expected min>max error, got: %v", err)
+		}
+	})
+
+	t.Run("hpa with non-numeric value returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "api",
+			Image: "nginx",
+			Annotations: map[string]string{
+				kubepose.HPAMaxReplicasAnnotationKey: "lots",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "must be a positive integer") {
+			t.Fatalf("expected positive-integer error, got: %v", err)
+		}
+	})
+
+	t.Run("workload statefulset with hpa targets statefulset", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "db",
+			Image: "postgres",
+			Annotations: map[string]string{
+				kubepose.WorkloadTypeAnnotationKey:   "StatefulSet",
+				kubepose.HPAMaxReplicasAnnotationKey: "5",
+			},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(resources.HorizontalPodAutoscalers) != 1 {
+			t.Fatalf("expected 1 HPA, got %d", len(resources.HorizontalPodAutoscalers))
+		}
+		ref := resources.HorizontalPodAutoscalers[0].Spec.ScaleTargetRef
+		if ref.Kind != "StatefulSet" || ref.Name != "db" {
+			t.Fatalf("expected StatefulSet/db target, got %+v", ref)
+		}
+	})
+
 	t.Run("CMD with empty command list still produces a probe", func(t *testing.T) {
 		t.Parallel()
 		// Documents current behavior: ["CMD"] with no following args

--- a/convert_test.go
+++ b/convert_test.go
@@ -102,6 +102,18 @@ func TestConvert(t *testing.T) {
 			Files:    []string{"testdata/hostpath/compose.yaml"},
 			Profiles: []string{"*"},
 		}, DryRun: TestRunKubectlDryRun | TestRunComposeDryRun},
+		{Name: "statefulset/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/statefulset/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun},
+		{Name: "cronjob/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/cronjob/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun},
+		{Name: "hpa/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/hpa/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/cronjobs.go
+++ b/cronjobs.go
@@ -1,0 +1,60 @@
+package kubepose
+
+import (
+	"github.com/compose-spec/compose-go/v2/types"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (t Transformer) createCronJob(resources *Resources, service types.ServiceConfig) *batchv1.CronJob {
+	serviceName := getServiceName(service)
+	schedule := service.Annotations[CronJobScheduleAnnotationKey]
+
+	for _, c := range resources.CronJobs {
+		if c.ObjectMeta.Name == serviceName {
+			return c
+		}
+	}
+
+	// Pods spawned by Jobs cannot use RestartPolicy=Always; coerce to OnFailure
+	// when the user has not chosen Never explicitly.
+	podSpec := t.createPodSpec(service)
+	if podSpec.RestartPolicy == corev1.RestartPolicyAlways {
+		podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
+	}
+
+	c := &batchv1.CronJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "CronJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceName,
+			Annotations: mergeMaps(service.Annotations, t.Annotations),
+			Labels:      mergeMaps(service.Labels, t.Labels),
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: schedule,
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: mergeMaps(service.Annotations, t.Annotations),
+					Labels:      mergeMaps(service.Labels, t.Labels),
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: mergeMaps(service.Annotations, t.Annotations),
+							Labels: mergeMaps(service.Labels, map[string]string{
+								AppSelectorLabelKey: serviceName,
+							}),
+						},
+						Spec: podSpec,
+					},
+				},
+			},
+		},
+	}
+	resources.CronJobs = append(resources.CronJobs, c)
+	return c
+}

--- a/hpa.go
+++ b/hpa.go
@@ -1,0 +1,93 @@
+package kubepose
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// hasHPA reports whether the service requested HPA generation via annotations.
+func hasHPA(service types.ServiceConfig) bool {
+	_, hasMin := service.Annotations[HPAMinReplicasAnnotationKey]
+	_, hasMax := service.Annotations[HPAMaxReplicasAnnotationKey]
+	return hasMin || hasMax
+}
+
+// createHorizontalPodAutoscaler emits an HPA targeting the given workload kind
+// (Deployment or StatefulSet).
+func (t Transformer) createHorizontalPodAutoscaler(service types.ServiceConfig, targetKind string) (*autoscalingv2.HorizontalPodAutoscaler, error) {
+	serviceName := getServiceName(service)
+
+	maxReplicas, err := positiveIntAnnotation(service, HPAMaxReplicasAnnotationKey, 0)
+	if err != nil {
+		return nil, err
+	}
+	if maxReplicas == 0 {
+		return nil, fmt.Errorf("hpa requires %s to be set to a positive integer", HPAMaxReplicasAnnotationKey)
+	}
+
+	minReplicas, err := positiveIntAnnotation(service, HPAMinReplicasAnnotationKey, 1)
+	if err != nil {
+		return nil, err
+	}
+	if minReplicas > maxReplicas {
+		return nil, fmt.Errorf("hpa minReplicas (%d) is greater than maxReplicas (%d)", minReplicas, maxReplicas)
+	}
+
+	var metrics []autoscalingv2.MetricSpec
+	if v, ok := service.Annotations[HPATargetCPUUtilizationAnnotationKey]; ok {
+		cpu, err := strconv.Atoi(v)
+		if err != nil || cpu <= 0 {
+			return nil, fmt.Errorf("invalid %s %q: must be a positive integer percentage", HPATargetCPUUtilizationAnnotationKey, v)
+		}
+		metrics = append(metrics, autoscalingv2.MetricSpec{
+			Type: autoscalingv2.ResourceMetricSourceType,
+			Resource: &autoscalingv2.ResourceMetricSource{
+				Name: corev1.ResourceCPU,
+				Target: autoscalingv2.MetricTarget{
+					Type:               autoscalingv2.UtilizationMetricType,
+					AverageUtilization: ptr.To(int32(cpu)),
+				},
+			},
+		})
+	}
+
+	return &autoscalingv2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "autoscaling/v2",
+			Kind:       "HorizontalPodAutoscaler",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceName,
+			Annotations: mergeMaps(service.Annotations, t.Annotations),
+			Labels:      mergeMaps(service.Labels, t.Labels),
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       targetKind,
+				Name:       serviceName,
+			},
+			MinReplicas: ptr.To(int32(minReplicas)),
+			MaxReplicas: int32(maxReplicas),
+			Metrics:     metrics,
+		},
+	}, nil
+}
+
+func positiveIntAnnotation(service types.ServiceConfig, key string, defaultValue int) (int, error) {
+	v, ok := service.Annotations[key]
+	if !ok {
+		return defaultValue, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n <= 0 {
+		return 0, fmt.Errorf("invalid %s %q: must be a positive integer", key, v)
+	}
+	return n, nil
+}

--- a/resources.go
+++ b/resources.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,15 +17,18 @@ import (
 )
 
 type Resources struct {
-	Pods                   []*corev1.Pod
-	Secrets                []*corev1.Secret
-	Services               []*corev1.Service
-	ConfigMaps             []*corev1.ConfigMap
-	DaemonSets             []*appsv1.DaemonSet
-	Deployments            []*appsv1.Deployment
-	Ingresses              []*networkingv1.Ingress
-	PersistentVolumeClaims []*corev1.PersistentVolumeClaim
-	ServiceAccounts        []*corev1.ServiceAccount
+	Pods                     []*corev1.Pod
+	Secrets                  []*corev1.Secret
+	Services                 []*corev1.Service
+	ConfigMaps               []*corev1.ConfigMap
+	DaemonSets               []*appsv1.DaemonSet
+	Deployments              []*appsv1.Deployment
+	StatefulSets             []*appsv1.StatefulSet
+	CronJobs                 []*batchv1.CronJob
+	HorizontalPodAutoscalers []*autoscalingv2.HorizontalPodAutoscaler
+	Ingresses                []*networkingv1.Ingress
+	PersistentVolumeClaims   []*corev1.PersistentVolumeClaim
+	ServiceAccounts          []*corev1.ServiceAccount
 }
 
 type k8sObject interface {
@@ -46,6 +51,9 @@ func (r *Resources) Write(writer io.Writer) error {
 	items = append(items, toObjects(r.Secrets)...)
 	items = append(items, toObjects(r.DaemonSets)...)
 	items = append(items, toObjects(r.Deployments)...)
+	items = append(items, toObjects(r.StatefulSets)...)
+	items = append(items, toObjects(r.CronJobs)...)
+	items = append(items, toObjects(r.HorizontalPodAutoscalers)...)
 	items = append(items, toObjects(r.Pods)...)
 	items = append(items, toObjects(r.Services)...)
 	items = append(items, toObjects(r.Ingresses)...)

--- a/statefulsets.go
+++ b/statefulsets.go
@@ -1,0 +1,54 @@
+package kubepose
+
+import (
+	"github.com/compose-spec/compose-go/v2/types"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func (t Transformer) createStatefulSet(resources *Resources, service types.ServiceConfig) *appsv1.StatefulSet {
+	serviceName := getServiceName(service)
+
+	for _, s := range resources.StatefulSets {
+		if s.ObjectMeta.Name == serviceName {
+			return s
+		}
+	}
+
+	var replicas *int32
+	if service.Deploy != nil && service.Deploy.Replicas != nil {
+		replicas = ptr.To(int32(*service.Deploy.Replicas))
+	}
+
+	s := &appsv1.StatefulSet{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "StatefulSet",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceName,
+			Annotations: mergeMaps(service.Annotations, t.Annotations),
+			Labels:      mergeMaps(service.Labels, t.Labels),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    replicas,
+			ServiceName: serviceName,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: getMatchLabels(service),
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: mergeMaps(service.Annotations, t.Annotations),
+					Labels: mergeMaps(service.Labels, map[string]string{
+						AppSelectorLabelKey: serviceName,
+					}),
+				},
+				Spec: t.createPodSpec(service),
+			},
+		},
+	}
+	resources.StatefulSets = append(resources.StatefulSets, s)
+	return s
+}

--- a/testdata/TestConvert/cronjob/k8s.yaml
+++ b/testdata/TestConvert/cronjob/k8s.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubepose.cronjob.schedule: 0 0 * * *
+  name: nightly-report
+spec:
+  jobTemplate:
+    metadata:
+      annotations:
+        kubepose.cronjob.schedule: 0 0 * * *
+    spec:
+      template:
+        metadata:
+          annotations:
+            kubepose.cronjob.schedule: 0 0 * * *
+          labels:
+            app.kubernetes.io/name: nightly-report
+        spec:
+          containers:
+          - args:
+            - sh
+            - -c
+            - echo running report
+            image: alpine:3
+            imagePullPolicy: IfNotPresent
+            name: nightly-report
+            resources: {}
+          restartPolicy: OnFailure
+  schedule: 0 0 * * *
+status: {}

--- a/testdata/TestConvert/hpa/k8s.yaml
+++ b/testdata/TestConvert/hpa/k8s.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubepose.hpa.maxReplicas: "10"
+    kubepose.hpa.minReplicas: "2"
+    kubepose.hpa.targetCPUUtilization: "75"
+  name: api
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kubepose.hpa.maxReplicas: "10"
+        kubepose.hpa.minReplicas: "2"
+        kubepose.hpa.targetCPUUtilization: "75"
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: IfNotPresent
+        name: api
+        ports:
+        - containerPort: 8080
+          protocol: TCP
+        resources: {}
+      restartPolicy: Always
+status: {}
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    kubepose.hpa.maxReplicas: "10"
+    kubepose.hpa.minReplicas: "2"
+    kubepose.hpa.targetCPUUtilization: "75"
+  name: api
+spec:
+  maxReplicas: 10
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 75
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+status:
+  currentMetrics: null
+  desiredReplicas: 0
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubepose.hpa.maxReplicas: "10"
+    kubepose.hpa.minReplicas: "2"
+    kubepose.hpa.targetCPUUtilization: "75"
+  name: api
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: api
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/statefulset/k8s.yaml
+++ b/testdata/TestConvert/statefulset/k8s.yaml
@@ -1,0 +1,50 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubepose.workload: StatefulSet
+  name: database
+spec:
+  ports:
+  - name: "5432"
+    port: 5432
+    protocol: TCP
+    targetPort: 5432
+  selector:
+    app.kubernetes.io/name: database
+status:
+  loadBalancer: {}
+
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  annotations:
+    kubepose.workload: StatefulSet
+  name: database
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: database
+  serviceName: database
+  template:
+    metadata:
+      annotations:
+        kubepose.workload: StatefulSet
+      labels:
+        app.kubernetes.io/name: database
+    spec:
+      containers:
+      - image: postgres:16
+        imagePullPolicy: IfNotPresent
+        name: database
+        ports:
+        - containerPort: 5432
+          protocol: TCP
+        resources: {}
+      restartPolicy: Always
+  updateStrategy: {}
+status:
+  availableReplicas: 0
+  replicas: 0

--- a/testdata/cronjob/compose.yaml
+++ b/testdata/cronjob/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  nightly-report:
+    image: alpine:3
+    command: ["sh", "-c", "echo running report"]
+    annotations:
+      kubepose.cronjob.schedule: "0 0 * * *"

--- a/testdata/hpa/compose.yaml
+++ b/testdata/hpa/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  api:
+    image: nginx
+    ports:
+      - "8080:8080"
+    annotations:
+      kubepose.hpa.minReplicas: "2"
+      kubepose.hpa.maxReplicas: "10"
+      kubepose.hpa.targetCPUUtilization: "75"

--- a/testdata/statefulset/compose.yaml
+++ b/testdata/statefulset/compose.yaml
@@ -1,0 +1,9 @@
+services:
+  database:
+    image: postgres:16
+    annotations:
+      kubepose.workload: StatefulSet
+    ports:
+      - "5432:5432"
+    deploy:
+      replicas: 3


### PR DESCRIPTION
## Summary

Adds three workload kinds previously listed as planned:

- **StatefulSet**: opt in via the annotation `kubepose.workload: StatefulSet`. Replaces Deployment for the service and sets `serviceName` to match.
- **CronJob**: set `kubepose.cronjob.schedule: "<cron>"` to emit a CronJob whose `JobTemplate` runs the compose service. Pod `restartPolicy` is coerced from `Always` to `OnFailure` since Jobs reject `Always`.
- **HorizontalPodAutoscaler**: set `kubepose.hpa.minReplicas`, `kubepose.hpa.maxReplicas`, and optionally `kubepose.hpa.targetCPUUtilization`. The HPA targets whichever workload was generated (Deployment or StatefulSet); pairing HPA with CronJob is rejected at validation time.

Refactors the `Convert` dispatch into a single `dispatchWorkload` helper that returns the inner pod spec pointer and workload kind, replacing the previous two-branch (DaemonSet/Deployment) inline conditional with four-way dispatch (CronJob/StatefulSet/DaemonSet/Deployment).

Adds snapshot tests for each new resource type and seven negative tests covering: unknown workload type, empty cron schedule, HPA on CronJob, missing/invalid HPA bounds, and HPA targeting a StatefulSet.

> Stacked on top of #113.

## Test plan
- [ ] `go test ./...`
- [ ] Convert a compose file using each new annotation and verify generated YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)