### PR TITLE
Add CronJob support via kubepose.cronjob.schedule annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The tests in the `testdata` directory are integration tests which also work as e
 | Init Containers | ✅ | Mark with `kubepose.container.type: init` |
 | Sidecar Containers | ✅ | Init containers with `restart: always` |
 | StatefulSets | 🚧 | Planned |
-| CronJobs | 🚧 | Planned |
+| CronJobs | ✅ | Enable with `kubepose.cronjob.schedule: "<cron>"` |
 
 ### Container Configuration
 

--- a/annotations.go
+++ b/annotations.go
@@ -12,13 +12,18 @@ const (
 	HealthcheckHttpGetPathAnnotationKey        = "kubepose.healthcheck.httpGet.path"
 	HealthcheckHttpGetPortAnnotationKey        = "kubepose.healthcheck.httpGet.port"
 	ContainerTypeAnnotationKey                 = "kubepose.container.type"
-	ConfigHmacKeyAnnotationKey                 = "kubepose.config.hmacKey"
-	SecretHmacKeyAnnotationKey                 = "kubepose.secret.hmacKey"
-	VolumeHmacKeyAnnotationKey                 = "kubepose.volume.hmacKey"
-	VolumeHostPathLabelKey                     = "kubepose.volume.hostPath"
-	VolumeStorageClassNameLabelKey             = "kubepose.volume.storageClassName"
-	VolumeSizeLabelKey                         = "kubepose.volume.size"
-	SecretSubPathLabelKey                      = "kubepose.secret.subPath"
+
+	// CronJobScheduleAnnotationKey, when set on a service, emits a CronJob
+	// using the value as the cron schedule (e.g. "0 * * * *").
+	CronJobScheduleAnnotationKey = "kubepose.cronjob.schedule"
+
+	ConfigHmacKeyAnnotationKey     = "kubepose.config.hmacKey"
+	SecretHmacKeyAnnotationKey     = "kubepose.secret.hmacKey"
+	VolumeHmacKeyAnnotationKey     = "kubepose.volume.hmacKey"
+	VolumeHostPathLabelKey         = "kubepose.volume.hostPath"
+	VolumeStorageClassNameLabelKey = "kubepose.volume.storageClassName"
+	VolumeSizeLabelKey             = "kubepose.volume.size"
+	SecretSubPathLabelKey          = "kubepose.secret.subPath"
 )
 
 // HMAC keys allow invalidation if the shape of an immutable

--- a/convert.go
+++ b/convert.go
@@ -56,7 +56,7 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 	groups := make(map[string][]types.ServiceConfig)
 	for _, service := range project.Services {
 		// Handle standalone pods (non-Always restart policy)
-		if getRestartPolicy(service) != corev1.RestartPolicyAlways && service.Annotations[ContainerTypeAnnotationKey] != "init" {
+		if _, isCronJob := service.Annotations[CronJobScheduleAnnotationKey]; !isCronJob && getRestartPolicy(service) != corev1.RestartPolicyAlways && service.Annotations[ContainerTypeAnnotationKey] != "init" {
 			pod := t.createPod(service)
 			pod.Spec.Containers = []corev1.Container{t.createContainer(service)}
 			t.updatePodSpecWithSecrets(&pod.Spec, service, secretMappings)
@@ -106,27 +106,25 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 		})
 
 		for _, service := range appServices {
-			if service.Deploy != nil && service.Deploy.Mode == "global" {
+			var podSpec *corev1.PodSpec
+			if _, ok := service.Annotations[CronJobScheduleAnnotationKey]; ok {
+				cj := t.createCronJob(resources, service)
+				podSpec = &cj.Spec.JobTemplate.Spec.Template.Spec
+			} else if service.Deploy != nil && service.Deploy.Mode == "global" {
 				ds := t.createDaemonSet(resources, service)
-				t.addContainersToSpec(&ds.Spec.Template.Spec, appServices, initServices)
-				for _, svc := range append(appServices, initServices...) {
-					t.updatePodSpecWithSecrets(&ds.Spec.Template.Spec, svc, secretMappings)
-					t.updatePodSpecWithConfigs(&ds.Spec.Template.Spec, svc, configMappings)
-					t.updatePodSpecWithVolumes(&ds.Spec.Template.Spec, svc, volumeMappings, resources)
-				}
-				removeDuplicateVolumeMounts(ds.Spec.Template.Spec.Containers)
-				removeDuplicateVolumeMounts(ds.Spec.Template.Spec.InitContainers)
+				podSpec = &ds.Spec.Template.Spec
 			} else {
 				deploy := t.createDeployment(resources, service)
-				t.addContainersToSpec(&deploy.Spec.Template.Spec, appServices, initServices)
-				for _, svc := range append(appServices, initServices...) {
-					t.updatePodSpecWithSecrets(&deploy.Spec.Template.Spec, svc, secretMappings)
-					t.updatePodSpecWithConfigs(&deploy.Spec.Template.Spec, svc, configMappings)
-					t.updatePodSpecWithVolumes(&deploy.Spec.Template.Spec, svc, volumeMappings, resources)
-				}
-				removeDuplicateVolumeMounts(deploy.Spec.Template.Spec.Containers)
-				removeDuplicateVolumeMounts(deploy.Spec.Template.Spec.InitContainers)
+				podSpec = &deploy.Spec.Template.Spec
 			}
+			t.addContainersToSpec(podSpec, appServices, initServices)
+			for _, svc := range append(appServices, initServices...) {
+				t.updatePodSpecWithSecrets(podSpec, svc, secretMappings)
+				t.updatePodSpecWithConfigs(podSpec, svc, configMappings)
+				t.updatePodSpecWithVolumes(podSpec, svc, volumeMappings, resources)
+			}
+			removeDuplicateVolumeMounts(podSpec.Containers)
+			removeDuplicateVolumeMounts(podSpec.InitContainers)
 
 			if len(service.Ports) > 0 {
 				svc := t.createService(service)
@@ -164,6 +162,9 @@ func validateService(service types.ServiceConfig) error {
 		default:
 			return fmt.Errorf("unsupported healthcheck test type %q (expected CMD, CMD-SHELL, or NONE)", service.HealthCheck.Test[0])
 		}
+	}
+	if schedule, ok := service.Annotations[CronJobScheduleAnnotationKey]; ok && schedule == "" {
+		return fmt.Errorf("%s must not be empty", CronJobScheduleAnnotationKey)
 	}
 	return nil
 }

--- a/convert_negative_test.go
+++ b/convert_negative_test.go
@@ -239,6 +239,21 @@ func TestConvertNegative(t *testing.T) {
 			t.Fatalf("expected empty Command, got %v", c.LivenessProbe.Exec.Command)
 		}
 	})
+
+	t.Run("empty cronjob schedule returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "job",
+			Image: "alpine",
+			Annotations: map[string]string{
+				kubepose.CronJobScheduleAnnotationKey: "",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "must not be empty") {
+			t.Fatalf("expected empty-schedule error, got: %v", err)
+		}
+	})
 }
 
 func projectWith(svc types.ServiceConfig) *types.Project {

--- a/convert_test.go
+++ b/convert_test.go
@@ -102,6 +102,10 @@ func TestConvert(t *testing.T) {
 			Files:    []string{"testdata/hostpath/compose.yaml"},
 			Profiles: []string{"*"},
 		}, DryRun: TestRunKubectlDryRun | TestRunComposeDryRun},
+		{Name: "cronjob/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/cronjob/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/cronjobs.go
+++ b/cronjobs.go
@@ -1,0 +1,60 @@
+package kubepose
+
+import (
+	"github.com/compose-spec/compose-go/v2/types"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (t Transformer) createCronJob(resources *Resources, service types.ServiceConfig) *batchv1.CronJob {
+	serviceName := getServiceName(service)
+	schedule := service.Annotations[CronJobScheduleAnnotationKey]
+
+	for _, c := range resources.CronJobs {
+		if c.ObjectMeta.Name == serviceName {
+			return c
+		}
+	}
+
+	// Pods spawned by Jobs cannot use RestartPolicy=Always; coerce to OnFailure
+	// when the user has not chosen Never explicitly.
+	podSpec := t.createPodSpec(service)
+	if podSpec.RestartPolicy == corev1.RestartPolicyAlways {
+		podSpec.RestartPolicy = corev1.RestartPolicyOnFailure
+	}
+
+	c := &batchv1.CronJob{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "batch/v1",
+			Kind:       "CronJob",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceName,
+			Annotations: mergeMaps(service.Annotations, t.Annotations),
+			Labels:      mergeMaps(service.Labels, t.Labels),
+		},
+		Spec: batchv1.CronJobSpec{
+			Schedule: schedule,
+			JobTemplate: batchv1.JobTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: mergeMaps(service.Annotations, t.Annotations),
+					Labels:      mergeMaps(service.Labels, t.Labels),
+				},
+				Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: mergeMaps(service.Annotations, t.Annotations),
+							Labels: mergeMaps(service.Labels, map[string]string{
+								AppSelectorLabelKey: serviceName,
+							}),
+						},
+						Spec: podSpec,
+					},
+				},
+			},
+		},
+	}
+	resources.CronJobs = append(resources.CronJobs, c)
+	return c
+}

--- a/resources.go
+++ b/resources.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,6 +22,7 @@ type Resources struct {
 	ConfigMaps             []*corev1.ConfigMap
 	DaemonSets             []*appsv1.DaemonSet
 	Deployments            []*appsv1.Deployment
+	CronJobs               []*batchv1.CronJob
 	Ingresses              []*networkingv1.Ingress
 	PersistentVolumeClaims []*corev1.PersistentVolumeClaim
 	ServiceAccounts        []*corev1.ServiceAccount
@@ -46,6 +48,7 @@ func (r *Resources) Write(writer io.Writer) error {
 	items = append(items, toObjects(r.Secrets)...)
 	items = append(items, toObjects(r.DaemonSets)...)
 	items = append(items, toObjects(r.Deployments)...)
+	items = append(items, toObjects(r.CronJobs)...)
 	items = append(items, toObjects(r.Pods)...)
 	items = append(items, toObjects(r.Services)...)
 	items = append(items, toObjects(r.Ingresses)...)

--- a/testdata/TestConvert/cronjob/k8s.yaml
+++ b/testdata/TestConvert/cronjob/k8s.yaml
@@ -1,0 +1,31 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations:
+    kubepose.cronjob.schedule: 0 * * * *
+  name: cleanup
+spec:
+  jobTemplate:
+    metadata:
+      annotations:
+        kubepose.cronjob.schedule: 0 * * * *
+    spec:
+      template:
+        metadata:
+          annotations:
+            kubepose.cronjob.schedule: 0 * * * *
+          labels:
+            app.kubernetes.io/name: cleanup
+        spec:
+          containers:
+          - args:
+            - sh
+            - -c
+            - echo cleaning up
+            image: alpine
+            imagePullPolicy: IfNotPresent
+            name: cleanup
+            resources: {}
+          restartPolicy: OnFailure
+  schedule: 0 * * * *
+status: {}

--- a/testdata/cronjob/compose.yaml
+++ b/testdata/cronjob/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  cleanup:
+    image: alpine
+    command: ["sh", "-c", "echo cleaning up"]
+    annotations:
+      kubepose.cronjob.schedule: "0 * * * *"


### PR DESCRIPTION
## Summary
This PR adds support for converting Docker Compose services into Kubernetes CronJobs. Services can now be marked as cron jobs by setting the `kubepose.cronjob.schedule` annotation with a valid cron expression.

## Key Changes
- **New CronJob creation**: Added `cronjobs.go` with `createCronJob()` method that generates Kubernetes CronJob resources from Compose services
- **Annotation support**: Introduced `CronJobScheduleAnnotationKey` constant (`kubepose.cronjob.schedule`) to enable CronJob configuration
- **Conversion logic**: Updated `Convert()` method to detect services with the cron schedule annotation and route them to CronJob creation instead of Deployment/DaemonSet
- **Pod spec handling**: Refactored pod spec configuration to work uniformly across Deployments, DaemonSets, and CronJobs by extracting common logic
- **Restart policy coercion**: CronJobs automatically coerce `RestartPolicy=Always` to `OnFailure` since Jobs don't support Always
- **Validation**: Added validation to ensure the cron schedule annotation is not empty
- **Test coverage**: Added integration test with example Compose file and expected Kubernetes output
- **Documentation**: Updated README to reflect CronJob support as completed (✅)

## Implementation Details
- CronJobs are handled as a separate resource type alongside Deployments and DaemonSets
- The conversion logic checks for the cron schedule annotation early to prevent treating cron services as standalone pods
- Pod spec configuration (containers, secrets, configs, volumes) is now applied uniformly to all workload types through a pointer-based approach
- The cron schedule value is used directly as the `spec.schedule` field in the generated CronJob

https://claude.ai/code/session_01WpY7aR6GfmeG9WqYcq8bcb