### PR TITLE
Add govulncheck to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,10 @@
 on:
   pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 6 * * 1'
 
 jobs:
   test:
@@ -11,3 +16,14 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go test -v -cover ./...
+
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,5 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: golang/govulncheck-action@v1
-        with:
-          go-version-file: go.mod
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: govulncheck ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/middle-management/kubepose
 
-go 1.26.0
+go 1.26.3
 
 require (
 	github.com/alexflint/go-arg v1.6.1


### PR DESCRIPTION
Scans for known vulnerabilities in dependencies and stdlib on every PR,
push to main, and weekly via cron so newly disclosed issues surface
even without code changes.