### PR TITLE
Bump Go to 1.26.4 to fix GO-2026-5037 govulncheck failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/middle-management/kubepose
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/alexflint/go-arg v1.6.1


### PR DESCRIPTION
govulncheck fails CI because Go 1.26.3's crypto/x509 is affected by
GO-2026-5037 (inefficient candidate hostname parsing), fixed in 1.26.4.
The workflow installs the toolchain from go.mod, so bumping the pin
resolves the vulnerability.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016d1xrSwga3DmMBV5e5w7p9