### PR TITLE
Add support for pre_start lifecycle hooks as init containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The tests in the `testdata` directory are integration tests which also work as e
 | Health Checks | ✅ | Supports test commands and HTTP checks |
 | User Settings | ✅ | Numeric user/group IDs only |
 | Stop Grace Period | ✅ | `stop_grace_period` maps to `terminationGracePeriodSeconds` (sub-second values round up) |
+| Pre-start Hooks | ✅ | `pre_start` maps to init containers |
 
 ### Networking
 
@@ -226,6 +227,46 @@ services:
 Note that some aspects of Docker Compose's update configuration don't have direct equivalents in Kubernetes:
 - `failure_action` is handled differently through Kubernetes' native deployment controller
 - `max_failure_ratio` has no direct equivalent
+
+### Pre-start Hooks
+
+Compose `pre_start` lifecycle hooks are converted to Kubernetes init containers, which match the compose contract: they run in declared order, each must exit successfully before the next starts, and the service container only starts once all of them have finished.
+
+```yaml
+services:
+  web:
+    image: nginx
+    volumes:
+      - data:/var/lib/data
+    pre_start:
+      # Uses the service's image and environment by default
+      - command: ./migrate.sh up
+      # Or bring your own image, user and working directory
+      - image: busybox
+        command: chown -R 1000:1000 /var/lib/data
+        user: "0:0"
+        working_dir: /var/lib/data
+
+volumes:
+  data:
+```
+
+Hook fields map as follows:
+
+| Compose Field | Kubernetes Field |
+|---------------|------------------|
+| `command` | init container `command` |
+| `image` | init container `image` (defaults to the service's image) |
+| `user` | `securityContext.runAsUser`/`runAsGroup` (numeric IDs only) |
+| `privileged` | `securityContext.privileged` |
+| `working_dir` | `workingDir` |
+| `environment` | `env` (service environment with hook overrides applied) |
+
+Hook containers inherit the service's volume mounts, matching compose's behavior of sharing the service's mounts.
+
+Differences from compose semantics:
+- `per_replica` has no Kubernetes equivalent: init containers always run once per pod, so every replica runs its own hooks.
+- Init containers re-run whenever a pod is (re)created, whereas compose skips hooks that already succeeded for an unchanged service.
 
 ## Contributing
 

--- a/containers.go
+++ b/containers.go
@@ -40,6 +40,82 @@ func (t Transformer) createContainer(service types.ServiceConfig) corev1.Contain
 	}
 }
 
+func preStartContainerName(service types.ServiceConfig, index int) string {
+	return fmt.Sprintf("%s-pre-start-%d", service.Name, index)
+}
+
+// createPreStartContainers converts a service's pre_start lifecycle hooks into
+// init containers. Kubernetes runs init containers sequentially and each must
+// exit 0 before the next starts, matching the compose pre_start contract.
+func (t Transformer) createPreStartContainers(service types.ServiceConfig) []corev1.Container {
+	var containers []corev1.Container
+	for i, hook := range service.PreStart {
+		image := hook.Image
+		if image == "" {
+			image = service.Image
+		}
+
+		env := make(types.MappingWithEquals, len(service.Environment)+len(hook.Environment))
+		for k, v := range service.Environment {
+			env[k] = v
+		}
+		for k, v := range hook.Environment {
+			env[k] = v
+		}
+
+		containers = append(containers, corev1.Container{
+			Name:            preStartContainerName(service, i),
+			Image:           image,
+			Command:         escapeEnvs(hook.Command),
+			WorkingDir:      hook.WorkingDir,
+			Env:             convertEnvironment(env),
+			ImagePullPolicy: getImagePullPolicy(service),
+			SecurityContext: getHookSecurityContext(hook),
+		})
+	}
+	return containers
+}
+
+// inheritPreStartVolumeMounts copies the parent service container's volume
+// mounts onto its pre_start init containers. The secret/config/volume plumbing
+// attaches mounts by matching container name to service name, which never
+// matches hook containers, so this must run after those updates.
+func inheritPreStartVolumeMounts(spec *corev1.PodSpec, service types.ServiceConfig) {
+	if len(service.PreStart) == 0 {
+		return
+	}
+
+	var parentMounts []corev1.VolumeMount
+	for _, container := range spec.Containers {
+		if container.Name == service.Name {
+			parentMounts = container.VolumeMounts
+			break
+		}
+	}
+	if parentMounts == nil {
+		for _, container := range spec.InitContainers {
+			if container.Name == service.Name {
+				parentMounts = container.VolumeMounts
+				break
+			}
+		}
+	}
+	if len(parentMounts) == 0 {
+		return
+	}
+
+	for i := range spec.InitContainers {
+		for hi := range service.PreStart {
+			if spec.InitContainers[i].Name == preStartContainerName(service, hi) {
+				spec.InitContainers[i].VolumeMounts = append(
+					spec.InitContainers[i].VolumeMounts,
+					parentMounts...,
+				)
+			}
+		}
+	}
+}
+
 func convertPorts(ports []types.ServicePortConfig) []corev1.ContainerPort {
 	var containerPorts []corev1.ContainerPort
 	for _, port := range ports {

--- a/convert.go
+++ b/convert.go
@@ -58,10 +58,12 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 		// Handle standalone pods (non-Always restart policy)
 		if _, isCronJob := service.Annotations[CronJobScheduleAnnotationKey]; !isCronJob && getRestartPolicy(service) != corev1.RestartPolicyAlways && service.Annotations[ContainerTypeAnnotationKey] != "init" {
 			pod := t.createPod(service)
+			pod.Spec.InitContainers = t.createPreStartContainers(service)
 			pod.Spec.Containers = []corev1.Container{t.createContainer(service)}
 			t.updatePodSpecWithSecrets(&pod.Spec, service, secretMappings)
 			t.updatePodSpecWithConfigs(&pod.Spec, service, configMappings)
 			t.updatePodSpecWithVolumes(&pod.Spec, service, volumeMappings, resources)
+			inheritPreStartVolumeMounts(&pod.Spec, service)
 			resources.Pods = append(resources.Pods, pod)
 			continue
 		}
@@ -122,6 +124,9 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 				t.updatePodSpecWithSecrets(podSpec, svc, secretMappings)
 				t.updatePodSpecWithConfigs(podSpec, svc, configMappings)
 				t.updatePodSpecWithVolumes(podSpec, svc, volumeMappings, resources)
+			}
+			for _, svc := range append(appServices, initServices...) {
+				inheritPreStartVolumeMounts(podSpec, svc)
 			}
 			removeDuplicateVolumeMounts(podSpec.Containers)
 			removeDuplicateVolumeMounts(podSpec.InitContainers)

--- a/convert_test.go
+++ b/convert_test.go
@@ -110,6 +110,10 @@ func TestConvert(t *testing.T) {
 			Files:    []string{"testdata/stop-grace-period/compose.yaml"},
 			Profiles: []string{"*"},
 		}, DryRun: TestRunKubectlDryRun | TestRunComposeDryRun},
+		{Name: "pre-start/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/pre-start/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/pod_spec.go
+++ b/pod_spec.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 )
 
 func (t Transformer) createPodSpec(service types.ServiceConfig) corev1.PodSpec {
@@ -55,28 +56,37 @@ func getRestartPolicy(service types.ServiceConfig) corev1.RestartPolicy {
 	return corev1.RestartPolicyAlways
 }
 
-func getSecurityContext(service types.ServiceConfig) *corev1.PodSecurityContext {
-	var runAsUser, runAsGroup, fsGroup *int64
-	var supplementalGroups []int64
+// parseUserGroupIDs parses a compose "user" value ("uid" or "uid:gid") into
+// numeric IDs, warning about named users/groups which Kubernetes cannot map.
+func parseUserGroupIDs(user string) (runAsUser, runAsGroup *int64) {
+	if user == "" {
+		return nil, nil
+	}
 
-	if service.User != "" {
-		parts := strings.Split(service.User, ":")
+	parts := strings.Split(user, ":")
 
-		if uid, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
-			runAsUser = &uid
+	if uid, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
+		runAsUser = &uid
+	} else {
+		fmt.Printf("Warning: skipping named user %q - only numeric IDs are supported\n", parts[0])
+	}
+
+	if len(parts) > 1 {
+		if gid, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
+			runAsGroup = &gid
 		} else {
-			fmt.Printf("Warning: skipping named user %q - only numeric IDs are supported\n", parts[0])
-		}
-
-		if len(parts) > 1 {
-			if gid, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
-				runAsGroup = &gid
-				fsGroup = &gid
-			} else {
-				fmt.Printf("Warning: skipping named group %q - only numeric IDs are supported\n", parts[1])
-			}
+			fmt.Printf("Warning: skipping named group %q - only numeric IDs are supported\n", parts[1])
 		}
 	}
+
+	return runAsUser, runAsGroup
+}
+
+func getSecurityContext(service types.ServiceConfig) *corev1.PodSecurityContext {
+	var supplementalGroups []int64
+
+	runAsUser, runAsGroup := parseUserGroupIDs(service.User)
+	fsGroup := runAsGroup
 
 	for _, g := range service.GroupAdd {
 		if gid, err := strconv.ParseInt(g, 10, 64); err == nil {
@@ -96,6 +106,22 @@ func getSecurityContext(service types.ServiceConfig) *corev1.PodSecurityContext 
 		FSGroup:            fsGroup,
 		SupplementalGroups: supplementalGroups,
 	}
+}
+
+func getHookSecurityContext(hook types.ServiceHook) *corev1.SecurityContext {
+	runAsUser, runAsGroup := parseUserGroupIDs(hook.User)
+	if runAsUser == nil && runAsGroup == nil && !hook.Privileged {
+		return nil
+	}
+
+	securityContext := &corev1.SecurityContext{
+		RunAsUser:  runAsUser,
+		RunAsGroup: runAsGroup,
+	}
+	if hook.Privileged {
+		securityContext.Privileged = ptr.To(true)
+	}
+	return securityContext
 }
 
 func getTopologySpreadConstraints(service types.ServiceConfig) []corev1.TopologySpreadConstraint {

--- a/testdata/TestConvert/pre-start/k8s.yaml
+++ b/testdata/TestConvert/pre-start/k8s.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: web
+    spec:
+      containers:
+      - env:
+        - name: DATA_DIR
+          value: /var/lib/data
+        image: nginx
+        imagePullPolicy: IfNotPresent
+        name: web
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/data
+          name: data
+      initContainers:
+      - command:
+        - /docker-entrypoint.d/migrate.sh
+        - up
+        env:
+        - name: DATA_DIR
+          value: /var/lib/data
+        - name: MIGRATION_STEP
+          value: "1"
+        image: nginx
+        imagePullPolicy: IfNotPresent
+        name: web-pre-start-0
+        resources: {}
+        volumeMounts:
+        - mountPath: /var/lib/data
+          name: data
+      - command:
+        - chown
+        - -R
+        - 1000:1000
+        - /var/lib/data
+        env:
+        - name: DATA_DIR
+          value: /var/lib/data
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        name: web-pre-start-1
+        resources: {}
+        securityContext:
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /var/lib/data
+          name: data
+        workingDir: /var/lib/data
+      restartPolicy: Always
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: data
+status: {}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: data
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+status: {}
+
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: migrate
+spec:
+  containers:
+  - args:
+    - echo
+    - done
+    image: alpine
+    imagePullPolicy: IfNotPresent
+    name: migrate
+    resources: {}
+  initContainers:
+  - command:
+    - echo
+    - preparing
+    image: alpine
+    imagePullPolicy: IfNotPresent
+    name: migrate-pre-start-0
+    resources: {}
+  restartPolicy: Never
+status: {}

--- a/testdata/pre-start/compose.yaml
+++ b/testdata/pre-start/compose.yaml
@@ -1,0 +1,28 @@
+services:
+  web:
+    image: nginx
+    environment:
+      DATA_DIR: /var/lib/data
+    volumes:
+      - data:/var/lib/data
+    pre_start:
+      # Runs with the service image and environment by default
+      - command: ["/docker-entrypoint.d/migrate.sh", "up"]
+        environment:
+          MIGRATION_STEP: "1"
+      # Runs with its own image, user and working directory
+      - image: busybox
+        command: chown -R 1000:1000 /var/lib/data
+        user: "0:0"
+        working_dir: /var/lib/data
+
+  # Standalone pod (non-Always restart policy) with a pre_start hook
+  migrate:
+    image: alpine
+    command: echo done
+    restart: "no"
+    pre_start:
+      - command: echo preparing
+
+volumes:
+  data:

--- a/workloads.go
+++ b/workloads.go
@@ -17,6 +17,8 @@ nextInitService:
 				continue nextInitService
 			}
 		}
+		// pre_start hooks run to completion before their service starts
+		podSpec.InitContainers = append(podSpec.InitContainers, t.createPreStartContainers(svc)...)
 		podSpec.InitContainers = append(podSpec.InitContainers, t.createContainer(svc))
 	}
 nextService:
@@ -26,6 +28,7 @@ nextService:
 				continue nextService
 			}
 		}
+		podSpec.InitContainers = append(podSpec.InitContainers, t.createPreStartContainers(svc)...)
 		podSpec.Containers = append(podSpec.Containers, t.createContainer(svc))
 	}
 }


### PR DESCRIPTION
Converts compose [`pre_start` lifecycle hooks](https://github.com/compose-spec/compose-spec/commit/a076fad2a10bb17111779156b5d9ec135458f885) into Kubernetes init containers. Init containers are a near-exact match for the compose contract: they run in declared order, each must exit 0 before the next starts, and the service container only starts once all of them have finished.

## Field mapping

| Compose field | Kubernetes field |
|---------------|------------------|
| `command` | init container `command` |
| `image` | init container `image` (defaults to the service's image) |
| `user` | `securityContext.runAsUser`/`runAsGroup` (numeric IDs only, same as service-level `user`) |
| `privileged` | `securityContext.privileged` |
| `working_dir` | `workingDir` |
| `environment` | `env` (service environment with hook overrides applied) |

Hook containers are named `<service>-pre-start-<index>` and inherit the parent service's volume mounts (secrets, configs, and volumes), matching compose's behavior of sharing the service's mounts. Hooks work in all workload paths: Deployments/DaemonSets/CronJobs, grouped multi-container pods (including `kubepose.container.type: init` services), and standalone Pods.

## Known semantic differences (documented in the README)

- `per_replica` has no per-pod equivalent — init containers always run once per pod, so every replica runs its own hooks. A once-service-wide hook would need a Job or a deploy-tool hook, which is out of kubepose's scope.
- Init containers re-run whenever a pod is (re)created, whereas compose skips hooks that already succeeded for an unchanged service.

## Implementation notes

- The shared `user` string parsing was extracted from `getSecurityContext` into `parseUserGroupIDs` so hooks reuse it; no behavior change for existing conversions.
- Volume-mount inheritance runs after the secret/config/volume plumbing since that plumbing matches containers by service name, which never matches hook container names.
- Added a `testdata/pre-start` fixture covering image defaulting, environment merge/override, `user`/`working_dir`, volume-mount inheritance, and the standalone-Pod path, with its golden snapshot validated by `kubectl apply --dry-run` in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142pUx1nPU91v8QRk9k4xLN

---
_Generated by [Claude Code](https://claude.ai/code/session_0142pUx1nPU91v8QRk9k4xLN)_