### PR TITLE
Add support for HPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The tests in the `testdata` directory are integration tests which also work as e
 | Sidecar Containers | ✅ | Init containers with `restart: always` |
 | StatefulSets | 🚧 | Planned |
 | CronJobs | ✅ | Enable with `kubepose.cronjob.schedule: "<cron>"` |
+| HorizontalPodAutoscalers | ✅ | Enable with `kubepose.hpa.maxReplicas: "<n>"` |
 
 ### Container Configuration
 
@@ -170,6 +171,33 @@ Key unsupported features include:
 | 🚧 | Coming Soon |
 | ❌ | Not Supported |
 
+
+### Autoscaling
+
+Setting `kubepose.hpa.maxReplicas` on a service emits an `autoscaling/v2`
+HorizontalPodAutoscaler targeting the service's Deployment, scaling on average
+CPU utilization:
+
+```yaml
+services:
+  web:
+    annotations:
+      kubepose.hpa.maxReplicas: 10 # required — enables the HPA
+      kubepose.hpa.minReplicas: 3  # optional — defaults to deploy.replicas, else 1
+      kubepose.hpa.cpu: 70         # optional — target average CPU %, defaults to 80
+    deploy:
+      replicas: 3
+      resources:
+        reservations:
+          cpus: "2" # required — utilization is a percentage of the CPU request
+          memory: 1G
+```
+
+The Deployment is emitted **without** `spec.replicas` so that re-applying
+manifests does not reset the scale the HPA has chosen. `deploy.replicas` still
+matters: it is the default `minReplicas`. The annotations are rejected on
+CronJob (`kubepose.cronjob.schedule`) and DaemonSet (`deploy.mode: global`)
+services, and require a CPU reservation.
 
 ### Update Strategies
 

--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ matters: it is the default `minReplicas`. The annotations are rejected on
 CronJob (`kubepose.cronjob.schedule`) and DaemonSet (`deploy.mode: global`)
 services, and require a CPU reservation.
 
+The generated HPA needs [metrics-server](https://github.com/kubernetes-sigs/metrics-server)
+running in the cluster (preinstalled or one click on most managed clusters).
+The CPU reservation must be explicit: a service with only `deploy.resources.limits`
+is rejected, even though Kubernetes would default the request from the limit.
+Memory-based targets are intentionally not supported — most runtimes do not
+release memory under reduced load, so memory utilization never drops and the
+HPA would scale up but never back down.
+
 ### Update Strategies
 
 kubepose supports Docker Compose's `update_config` for controlling how services are updated:

--- a/annotations.go
+++ b/annotations.go
@@ -17,6 +17,20 @@ const (
 	// using the value as the cron schedule (e.g. "0 * * * *").
 	CronJobScheduleAnnotationKey = "kubepose.cronjob.schedule"
 
+	// HpaMaxReplicasAnnotationKey, when set on a service, emits an
+	// autoscaling/v2 HorizontalPodAutoscaler targeting the service's
+	// Deployment, scaling on average CPU utilization. The Deployment is
+	// emitted without spec.replicas so re-applies don't reset the HPA's
+	// chosen scale. Requires deploy.resources.reservations.cpus, since
+	// utilization is a percentage of the CPU request.
+	HpaMaxReplicasAnnotationKey = "kubepose.hpa.maxReplicas"
+	// HpaMinReplicasAnnotationKey sets the HPA's floor. Defaults to
+	// deploy.replicas, else 1.
+	HpaMinReplicasAnnotationKey = "kubepose.hpa.minReplicas"
+	// HpaCpuUtilizationAnnotationKey sets the HPA's target average CPU
+	// utilization percentage. Defaults to 80.
+	HpaCpuUtilizationAnnotationKey = "kubepose.hpa.cpu"
+
 	ConfigHmacKeyAnnotationKey     = "kubepose.config.hmacKey"
 	SecretHmacKeyAnnotationKey     = "kubepose.secret.hmacKey"
 	VolumeHmacKeyAnnotationKey     = "kubepose.volume.hmacKey"

--- a/annotations.go
+++ b/annotations.go
@@ -27,9 +27,9 @@ const (
 	// HpaMinReplicasAnnotationKey sets the HPA's floor. Defaults to
 	// deploy.replicas, else 1.
 	HpaMinReplicasAnnotationKey = "kubepose.hpa.minReplicas"
-	// HpaCpuUtilizationAnnotationKey sets the HPA's target average CPU
-	// utilization percentage. Defaults to 80.
-	HpaCpuUtilizationAnnotationKey = "kubepose.hpa.cpu"
+	// HpaCpuAnnotationKey sets the HPA's target average CPU utilization
+	// percentage. Defaults to 80.
+	HpaCpuAnnotationKey = "kubepose.hpa.cpu"
 
 	ConfigHmacKeyAnnotationKey     = "kubepose.config.hmacKey"
 	SecretHmacKeyAnnotationKey     = "kubepose.secret.hmacKey"

--- a/convert.go
+++ b/convert.go
@@ -180,6 +180,18 @@ func validateService(service types.ServiceConfig) error {
 	if schedule, ok := service.Annotations[CronJobScheduleAnnotationKey]; ok && schedule == "" {
 		return fmt.Errorf("%s must not be empty", CronJobScheduleAnnotationKey)
 	}
+	// Reject HPA annotations on the two service shapes that never reach the
+	// Deployment branch in Convert; they would otherwise be silent no-ops.
+	// Checked here (not in validateHpaAnnotations) to keep getRestartPolicy
+	// and corev1 usage in the file that already imports them.
+	if _, hasHpa := service.Annotations[HpaMaxReplicasAnnotationKey]; hasHpa {
+		if service.Annotations[ContainerTypeAnnotationKey] == "init" {
+			return fmt.Errorf("%s has no effect on an init container service", HpaMaxReplicasAnnotationKey)
+		}
+		if getRestartPolicy(service) != corev1.RestartPolicyAlways {
+			return fmt.Errorf("%s requires restart: always (the service converts to a standalone Pod, which cannot be autoscaled)", HpaMaxReplicasAnnotationKey)
+		}
+	}
 	return validateHpaAnnotations(service)
 }
 

--- a/convert.go
+++ b/convert.go
@@ -118,6 +118,15 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 			} else {
 				deploy := t.createDeployment(resources, service)
 				podSpec = &deploy.Spec.Template.Spec
+				if hasHorizontalPodAutoscaler(service) {
+					// The HPA owns the replica count; a pinned spec.replicas
+					// would reset its chosen scale on every apply. Cleared
+					// here rather than in createDeployment so it also covers
+					// a grouped service whose Deployment was created first
+					// by another member.
+					deploy.Spec.Replicas = nil
+					t.createHorizontalPodAutoscaler(resources, service)
+				}
 			}
 			t.addContainersToSpec(podSpec, appServices, initServices)
 			for _, svc := range append(appServices, initServices...) {
@@ -171,7 +180,7 @@ func validateService(service types.ServiceConfig) error {
 	if schedule, ok := service.Annotations[CronJobScheduleAnnotationKey]; ok && schedule == "" {
 		return fmt.Errorf("%s must not be empty", CronJobScheduleAnnotationKey)
 	}
-	return nil
+	return validateHpaAnnotations(service)
 }
 
 // getServiceName returns the kubernetes resource name for a compose service:

--- a/convert_negative_test.go
+++ b/convert_negative_test.go
@@ -279,18 +279,36 @@ func TestConvertHpaValidation(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name: "min or cpu without maxReplicas",
+			name: "minReplicas without maxReplicas names only the set key",
 			service: types.ServiceConfig{
 				Name: "web", Image: "nginx",
 				Annotations: map[string]string{kubepose.HpaMinReplicasAnnotationKey: "2"},
 			},
-			wantErr: "no effect without",
+			wantErr: kubepose.HpaMinReplicasAnnotationKey + " has no effect without",
+		},
+		{
+			name: "cpu without maxReplicas names only the set key",
+			service: types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{kubepose.HpaCpuAnnotationKey: "70"},
+			},
+			wantErr: kubepose.HpaCpuAnnotationKey + " has no effect without",
 		},
 		{
 			name: "non-numeric maxReplicas",
 			service: withCpuReservation(types.ServiceConfig{
 				Name: "web", Image: "nginx",
 				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "lots"},
+			}),
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "maxReplicas overflowing int32 is rejected, not truncated",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				// int32-truncates to 3; must fail validation instead of
+				// emitting a plausible-looking wrong HPA.
+				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "4294967299"},
 			}),
 			wantErr: "must be a positive integer",
 		},
@@ -319,8 +337,8 @@ func TestConvertHpaValidation(t *testing.T) {
 			service: withCpuReservation(types.ServiceConfig{
 				Name: "web", Image: "nginx",
 				Annotations: map[string]string{
-					kubepose.HpaMaxReplicasAnnotationKey:    "3",
-					kubepose.HpaCpuUtilizationAnnotationKey: "0",
+					kubepose.HpaMaxReplicasAnnotationKey: "3",
+					kubepose.HpaCpuAnnotationKey:         "0",
 				},
 			}),
 			wantErr: "positive integer percentage",
@@ -355,6 +373,26 @@ func TestConvertHpaValidation(t *testing.T) {
 				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "3"},
 			},
 			wantErr: "requires deploy.resources.reservations.cpus",
+		},
+		{
+			name: "standalone-pod service (restart: no) is rejected, not a silent no-op",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Restart:     "no",
+				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "3"},
+			}),
+			wantErr: "requires restart: always",
+		},
+		{
+			name: "init container service is rejected, not a silent no-op",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{
+					kubepose.HpaMaxReplicasAnnotationKey: "3",
+					kubepose.ContainerTypeAnnotationKey:  "init",
+				},
+			}),
+			wantErr: "has no effect on an init container",
 		},
 	}
 

--- a/convert_negative_test.go
+++ b/convert_negative_test.go
@@ -261,3 +261,115 @@ func projectWith(svc types.ServiceConfig) *types.Project {
 		Services: types.Services{svc.Name: svc},
 	}
 }
+
+func TestConvertHpaValidation(t *testing.T) {
+	t.Parallel()
+
+	withCpuReservation := func(svc types.ServiceConfig) types.ServiceConfig {
+		if svc.Deploy == nil {
+			svc.Deploy = &types.DeployConfig{}
+		}
+		svc.Deploy.Resources.Reservations = &types.Resource{NanoCPUs: 2}
+		return svc
+	}
+
+	cases := []struct {
+		name    string
+		service types.ServiceConfig
+		wantErr string
+	}{
+		{
+			name: "min or cpu without maxReplicas",
+			service: types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{kubepose.HpaMinReplicasAnnotationKey: "2"},
+			},
+			wantErr: "no effect without",
+		},
+		{
+			name: "non-numeric maxReplicas",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "lots"},
+			}),
+			wantErr: "must be a positive integer",
+		},
+		{
+			name: "minReplicas above maxReplicas",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{
+					kubepose.HpaMinReplicasAnnotationKey: "5",
+					kubepose.HpaMaxReplicasAnnotationKey: "3",
+				},
+			}),
+			wantErr: "must not exceed",
+		},
+		{
+			name: "deploy.replicas above maxReplicas as implicit floor",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Deploy:      &types.DeployConfig{Replicas: intPtr(8)},
+				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "3"},
+			}),
+			wantErr: "must not exceed",
+		},
+		{
+			name: "zero cpu target",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{
+					kubepose.HpaMaxReplicasAnnotationKey:    "3",
+					kubepose.HpaCpuUtilizationAnnotationKey: "0",
+				},
+			}),
+			wantErr: "positive integer percentage",
+		},
+		{
+			name: "combined with cronjob schedule",
+			service: withCpuReservation(types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{
+					kubepose.HpaMaxReplicasAnnotationKey:  "3",
+					kubepose.CronJobScheduleAnnotationKey: "0 * * * *",
+				},
+			}),
+			wantErr: "cannot be combined with",
+		},
+		{
+			name: "combined with global mode",
+			service: types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Deploy: &types.DeployConfig{
+					Mode:      "global",
+					Resources: types.Resources{Reservations: &types.Resource{NanoCPUs: 1}},
+				},
+				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "3"},
+			},
+			wantErr: "deploy.mode: global",
+		},
+		{
+			name: "missing cpu reservation",
+			service: types.ServiceConfig{
+				Name: "web", Image: "nginx",
+				Annotations: map[string]string{kubepose.HpaMaxReplicasAnnotationKey: "3"},
+			},
+			wantErr: "requires deploy.resources.reservations.cpus",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := kubepose.Transformer{}.Convert(projectWith(tc.service))
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tc.wantErr, err)
+			}
+		})
+	}
+}
+
+func intPtr(i int) *int { return &i }

--- a/convert_test.go
+++ b/convert_test.go
@@ -114,6 +114,10 @@ func TestConvert(t *testing.T) {
 			Files:    []string{"testdata/pre-start/compose.yaml"},
 			Profiles: []string{"*"},
 		}, DryRun: TestRunKubectlDryRun},
+		{Name: "hpa/k8s.yaml", Options: project.Options{
+			Files:    []string{"testdata/hpa/compose.yaml"},
+			Profiles: []string{"*"},
+		}, DryRun: TestRunKubectlDryRun},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/hpa.go
+++ b/hpa.go
@@ -44,11 +44,14 @@ func (t Transformer) createHorizontalPodAutoscaler(resources *Resources, service
 	if value, ok := service.Annotations[HpaMinReplicasAnnotationKey]; ok {
 		minReplicas, _ = strconv.Atoi(value)
 	} else if service.Deploy != nil && service.Deploy.Replicas != nil {
+		// For grouped services this reads deploy.replicas from the annotated
+		// member only — consistent with group-merge semantics elsewhere,
+		// where the annotated service's Deployment-level fields win.
 		minReplicas = *service.Deploy.Replicas
 	}
 
 	cpuUtilization := hpaDefaultCpuUtilization
-	if value, ok := service.Annotations[HpaCpuUtilizationAnnotationKey]; ok {
+	if value, ok := service.Annotations[HpaCpuAnnotationKey]; ok {
 		cpuUtilization, _ = strconv.Atoi(value)
 	}
 
@@ -93,29 +96,33 @@ func (t Transformer) createHorizontalPodAutoscaler(resources *Resources, service
 func validateHpaAnnotations(service types.ServiceConfig) error {
 	maxValue, hasMax := service.Annotations[HpaMaxReplicasAnnotationKey]
 	minValue, hasMin := service.Annotations[HpaMinReplicasAnnotationKey]
-	cpuValue, hasCpu := service.Annotations[HpaCpuUtilizationAnnotationKey]
+	cpuValue, hasCpu := service.Annotations[HpaCpuAnnotationKey]
 
 	if !hasMax {
-		if hasMin || hasCpu {
-			return fmt.Errorf("%s and %s have no effect without %s",
-				HpaMinReplicasAnnotationKey, HpaCpuUtilizationAnnotationKey, HpaMaxReplicasAnnotationKey)
+		if hasMin {
+			return fmt.Errorf("%s has no effect without %s", HpaMinReplicasAnnotationKey, HpaMaxReplicasAnnotationKey)
+		}
+		if hasCpu {
+			return fmt.Errorf("%s has no effect without %s", HpaCpuAnnotationKey, HpaMaxReplicasAnnotationKey)
 		}
 		return nil
 	}
 
-	maxReplicas, err := strconv.Atoi(maxValue)
+	// ParseInt with bitSize 32 so out-of-range values fail here instead of
+	// silently truncating in createHorizontalPodAutoscaler's int32 casts.
+	maxReplicas, err := strconv.ParseInt(maxValue, 10, 32)
 	if err != nil || maxReplicas < 1 {
 		return fmt.Errorf("%s must be a positive integer, got %q", HpaMaxReplicasAnnotationKey, maxValue)
 	}
 
-	minReplicas := 1
+	minReplicas := int64(1)
 	if hasMin {
-		minReplicas, err = strconv.Atoi(minValue)
+		minReplicas, err = strconv.ParseInt(minValue, 10, 32)
 		if err != nil || minReplicas < 1 {
 			return fmt.Errorf("%s must be a positive integer, got %q", HpaMinReplicasAnnotationKey, minValue)
 		}
 	} else if service.Deploy != nil && service.Deploy.Replicas != nil {
-		minReplicas = *service.Deploy.Replicas
+		minReplicas = int64(*service.Deploy.Replicas)
 	}
 	if minReplicas > maxReplicas {
 		return fmt.Errorf("%s (%d) must not exceed %s (%d)",
@@ -123,9 +130,9 @@ func validateHpaAnnotations(service types.ServiceConfig) error {
 	}
 
 	if hasCpu {
-		cpuUtilization, err := strconv.Atoi(cpuValue)
+		cpuUtilization, err := strconv.ParseInt(cpuValue, 10, 32)
 		if err != nil || cpuUtilization < 1 {
-			return fmt.Errorf("%s must be a positive integer percentage, got %q", HpaCpuUtilizationAnnotationKey, cpuValue)
+			return fmt.Errorf("%s must be a positive integer percentage, got %q", HpaCpuAnnotationKey, cpuValue)
 		}
 	}
 

--- a/hpa.go
+++ b/hpa.go
@@ -1,0 +1,150 @@
+package kubepose
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/compose-spec/compose-go/v2/types"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+// hpaDefaultCpuUtilization is the target average CPU utilization (percent of
+// the container's CPU request) used when kubepose.hpa.cpu is not set.
+const hpaDefaultCpuUtilization = 80
+
+// hasHorizontalPodAutoscaler reports whether the service opts into an HPA.
+// kubepose.hpa.maxReplicas is the enabling annotation; the others refine it.
+func hasHorizontalPodAutoscaler(service types.ServiceConfig) bool {
+	_, ok := service.Annotations[HpaMaxReplicasAnnotationKey]
+	return ok
+}
+
+// createHorizontalPodAutoscaler emits an autoscaling/v2 HPA targeting the
+// service's Deployment, scaling on average CPU utilization.
+//
+// The Deployment's spec.replicas must be left unset when an HPA manages it
+// (see createDeployment): a pinned value would reset the HPA's chosen scale
+// on every apply. minReplicas defaults to deploy.replicas so an existing
+// `deploy.replicas: N` service keeps its floor when the HPA is enabled.
+func (t Transformer) createHorizontalPodAutoscaler(resources *Resources, service types.ServiceConfig) *autoscalingv2.HorizontalPodAutoscaler {
+	serviceName := getServiceName(service)
+
+	for _, hpa := range resources.HorizontalPodAutoscalers {
+		if hpa.ObjectMeta.Name == serviceName {
+			return hpa
+		}
+	}
+
+	// Values are validated in validateService; parse errors cannot occur here.
+	maxReplicas, _ := strconv.Atoi(service.Annotations[HpaMaxReplicasAnnotationKey])
+
+	minReplicas := 1
+	if value, ok := service.Annotations[HpaMinReplicasAnnotationKey]; ok {
+		minReplicas, _ = strconv.Atoi(value)
+	} else if service.Deploy != nil && service.Deploy.Replicas != nil {
+		minReplicas = *service.Deploy.Replicas
+	}
+
+	cpuUtilization := hpaDefaultCpuUtilization
+	if value, ok := service.Annotations[HpaCpuUtilizationAnnotationKey]; ok {
+		cpuUtilization, _ = strconv.Atoi(value)
+	}
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "autoscaling/v2",
+			Kind:       "HorizontalPodAutoscaler",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        serviceName,
+			Annotations: mergeMaps(service.Annotations, t.Annotations),
+			Labels:      mergeMaps(service.Labels, t.Labels),
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       serviceName,
+			},
+			MinReplicas: ptr.To(int32(minReplicas)),
+			MaxReplicas: int32(maxReplicas),
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: "cpu",
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: ptr.To(int32(cpuUtilization)),
+						},
+					},
+				},
+			},
+		},
+	}
+	resources.HorizontalPodAutoscalers = append(resources.HorizontalPodAutoscalers, hpa)
+	return hpa
+}
+
+// validateHpaAnnotations rejects HPA annotation combinations the converter
+// cannot faithfully translate. Called from validateService.
+func validateHpaAnnotations(service types.ServiceConfig) error {
+	maxValue, hasMax := service.Annotations[HpaMaxReplicasAnnotationKey]
+	minValue, hasMin := service.Annotations[HpaMinReplicasAnnotationKey]
+	cpuValue, hasCpu := service.Annotations[HpaCpuUtilizationAnnotationKey]
+
+	if !hasMax {
+		if hasMin || hasCpu {
+			return fmt.Errorf("%s and %s have no effect without %s",
+				HpaMinReplicasAnnotationKey, HpaCpuUtilizationAnnotationKey, HpaMaxReplicasAnnotationKey)
+		}
+		return nil
+	}
+
+	maxReplicas, err := strconv.Atoi(maxValue)
+	if err != nil || maxReplicas < 1 {
+		return fmt.Errorf("%s must be a positive integer, got %q", HpaMaxReplicasAnnotationKey, maxValue)
+	}
+
+	minReplicas := 1
+	if hasMin {
+		minReplicas, err = strconv.Atoi(minValue)
+		if err != nil || minReplicas < 1 {
+			return fmt.Errorf("%s must be a positive integer, got %q", HpaMinReplicasAnnotationKey, minValue)
+		}
+	} else if service.Deploy != nil && service.Deploy.Replicas != nil {
+		minReplicas = *service.Deploy.Replicas
+	}
+	if minReplicas > maxReplicas {
+		return fmt.Errorf("%s (%d) must not exceed %s (%d)",
+			HpaMinReplicasAnnotationKey, minReplicas, HpaMaxReplicasAnnotationKey, maxReplicas)
+	}
+
+	if hasCpu {
+		cpuUtilization, err := strconv.Atoi(cpuValue)
+		if err != nil || cpuUtilization < 1 {
+			return fmt.Errorf("%s must be a positive integer percentage, got %q", HpaCpuUtilizationAnnotationKey, cpuValue)
+		}
+	}
+
+	// An HPA only targets Deployments; the other workload kinds have no scale
+	// subresource in kubepose's output.
+	if _, isCronJob := service.Annotations[CronJobScheduleAnnotationKey]; isCronJob {
+		return fmt.Errorf("%s cannot be combined with %s", HpaMaxReplicasAnnotationKey, CronJobScheduleAnnotationKey)
+	}
+	if service.Deploy != nil && service.Deploy.Mode == "global" {
+		return fmt.Errorf("%s cannot be used with deploy.mode: global", HpaMaxReplicasAnnotationKey)
+	}
+
+	// The CPU-utilization metric is a percentage of the container's CPU
+	// request; without a reservation the HPA can never compute utilization.
+	if service.Deploy == nil ||
+		service.Deploy.Resources.Reservations == nil ||
+		service.Deploy.Resources.Reservations.NanoCPUs.Value() <= 0 {
+		return fmt.Errorf("%s requires deploy.resources.reservations.cpus (the HPA CPU target is a percentage of the request)", HpaMaxReplicasAnnotationKey)
+	}
+
+	return nil
+}

--- a/resources.go
+++ b/resources.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -16,16 +17,17 @@ import (
 )
 
 type Resources struct {
-	Pods                   []*corev1.Pod
-	Secrets                []*corev1.Secret
-	Services               []*corev1.Service
-	ConfigMaps             []*corev1.ConfigMap
-	DaemonSets             []*appsv1.DaemonSet
-	Deployments            []*appsv1.Deployment
-	CronJobs               []*batchv1.CronJob
-	Ingresses              []*networkingv1.Ingress
-	PersistentVolumeClaims []*corev1.PersistentVolumeClaim
-	ServiceAccounts        []*corev1.ServiceAccount
+	Pods                     []*corev1.Pod
+	Secrets                  []*corev1.Secret
+	Services                 []*corev1.Service
+	ConfigMaps               []*corev1.ConfigMap
+	DaemonSets               []*appsv1.DaemonSet
+	Deployments              []*appsv1.Deployment
+	CronJobs                 []*batchv1.CronJob
+	HorizontalPodAutoscalers []*autoscalingv2.HorizontalPodAutoscaler
+	Ingresses                []*networkingv1.Ingress
+	PersistentVolumeClaims   []*corev1.PersistentVolumeClaim
+	ServiceAccounts          []*corev1.ServiceAccount
 }
 
 type k8sObject interface {
@@ -49,6 +51,7 @@ func (r *Resources) Write(writer io.Writer) error {
 	items = append(items, toObjects(r.DaemonSets)...)
 	items = append(items, toObjects(r.Deployments)...)
 	items = append(items, toObjects(r.CronJobs)...)
+	items = append(items, toObjects(r.HorizontalPodAutoscalers)...)
 	items = append(items, toObjects(r.Pods)...)
 	items = append(items, toObjects(r.Services)...)
 	items = append(items, toObjects(r.Ingresses)...)

--- a/testdata/TestConvert/hpa/k8s.yaml
+++ b/testdata/TestConvert/hpa/k8s.yaml
@@ -1,0 +1,138 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubepose.hpa.cpu: "70"
+    kubepose.hpa.maxReplicas: "6"
+    kubepose.hpa.minReplicas: "2"
+  name: api
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: api
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kubepose.hpa.cpu: "70"
+        kubepose.hpa.maxReplicas: "6"
+        kubepose.hpa.minReplicas: "2"
+      labels:
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: IfNotPresent
+        name: api
+        resources:
+          requests:
+            cpu: 500m
+            memory: 256Mi
+      restartPolicy: Always
+status: {}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kubepose.hpa.maxReplicas: "10"
+  name: web
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: web
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        kubepose.hpa.maxReplicas: "10"
+      labels:
+        app.kubernetes.io/name: web
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: IfNotPresent
+        name: web
+        resources:
+          requests:
+            cpu: "2"
+            memory: 1Gi
+      restartPolicy: Always
+status: {}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: worker
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: worker
+    spec:
+      containers:
+      - image: nginx
+        imagePullPolicy: IfNotPresent
+        name: worker
+        resources: {}
+      restartPolicy: Always
+status: {}
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    kubepose.hpa.cpu: "70"
+    kubepose.hpa.maxReplicas: "6"
+    kubepose.hpa.minReplicas: "2"
+  name: api
+spec:
+  maxReplicas: 6
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 70
+        type: Utilization
+    type: Resource
+  minReplicas: 2
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api
+status:
+  currentMetrics: null
+  desiredReplicas: 0
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  annotations:
+    kubepose.hpa.maxReplicas: "10"
+  name: web
+spec:
+  maxReplicas: 10
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
+  minReplicas: 3
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: web
+status:
+  currentMetrics: null
+  desiredReplicas: 0

--- a/testdata/hpa/compose.yaml
+++ b/testdata/hpa/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  # HPA floor from deploy.replicas, default 80% CPU target
+  web:
+    image: nginx
+    annotations:
+      kubepose.hpa.maxReplicas: 10
+    deploy:
+      replicas: 3
+      resources:
+        reservations:
+          cpus: "2"
+          memory: 1G
+
+  # Explicit floor and CPU target; no deploy.replicas at all
+  api:
+    image: nginx
+    annotations:
+      kubepose.hpa.minReplicas: 2
+      kubepose.hpa.maxReplicas: 6
+      kubepose.hpa.cpu: 70
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.5"
+          memory: 256M
+
+  # No HPA annotations — Deployment keeps its pinned replicas
+  worker:
+    image: nginx
+    deploy:
+      replicas: 2


### PR DESCRIPTION
kubepose.hpa.maxReplicas on a service emits an autoscaling/v2 HPA targeting its Deployment, scaling on average CPU utilization. kubepose.hpa.minReplicas defaults to deploy.replicas (else 1) and kubepose.hpa.cpu defaults to 80. The Deployment is emitted without spec.replicas so re-applies don't reset the HPA's chosen scale.

Validation rejects: min/cpu without maxReplicas, non-positive or non-numeric values, a floor above the ceiling (explicit or via deploy.replicas), combination with CronJob or global-mode services, and services without a CPU reservation (utilization is a percentage of the request).