### PR TITLE
Enforce compose parity: DNS for portless services, errors over silent divergence

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The tests in the `testdata` directory are integration tests which also work as e
 | Shell Access | ✅ | `stdin_open` and `tty` |
 | Resource Limits | ✅ | CPU and memory constraints |
 | Health Checks | ✅ | Supports test commands and HTTP checks |
-| User Settings | ✅ | Numeric user/group IDs only |
+| User Settings | ✅ | Numeric user/group IDs only; named IDs fail conversion since they would resolve differently than in local compose |
 | Stop Grace Period | ✅ | `stop_grace_period` maps to `terminationGracePeriodSeconds` (sub-second values round up) |
 | Pre-start Hooks | ✅ | `pre_start` maps to init containers |
 
@@ -117,8 +117,9 @@ The tests in the `testdata` directory are integration tests which also work as e
 | Feature | Status | Description |
 |---------|:------:|-------------|
 | Ports | ✅ | TCP/UDP port mapping |
+| Expose | ✅ | `expose` entries become Service ports (no host publishing) |
 | Service Exposure | ✅ | Via Kubernetes annotations |
-| Internal DNS | ❌ | Use Kubernetes DNS instead |
+| Internal DNS | ✅ | Every long-running service gets a Kubernetes Service, headless when it declares no ports, so services resolve by name like on the compose network |
 | Custom Networks | ❌ | Use Kubernetes networking |
 
 ### Storage & State

--- a/convert.go
+++ b/convert.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/compose-spec/compose-go/v2/types"
@@ -97,6 +98,9 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 		}
 
 		if len(appServices) == 0 {
+			if len(initServices) > 0 {
+				return nil, fmt.Errorf("group %q contains only %s: init services, which would silently produce nothing; a sidecar needs an app service in its group", groupName, ContainerTypeAnnotationKey)
+			}
 			continue
 		}
 
@@ -141,16 +145,25 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 			removeDuplicateVolumeMounts(podSpec.Containers)
 			removeDuplicateVolumeMounts(podSpec.InitContainers)
 
-			if len(service.Ports) > 0 {
+			// Every long-running service gets a Kubernetes Service so it is
+			// resolvable by name like in local compose (headless when it
+			// declares no ports). CronJob pods are short-lived, so they only
+			// get one when they declare ports.
+			_, isCronJob := service.Annotations[CronJobScheduleAnnotationKey]
+			if len(service.Ports) > 0 || len(service.Expose) > 0 || !isCronJob {
 				svc := t.createService(service)
-				found := false
+				var existing *corev1.Service
 				for _, s := range resources.Services {
 					if s.ObjectMeta.Name == svc.ObjectMeta.Name {
-						found = true
+						existing = s
 						break
 					}
 				}
-				if !found {
+				if existing != nil {
+					// Another group member created the Service first; fold in
+					// this member's ports so declaration order doesn't matter.
+					mergeServicePorts(existing, svc.Spec.Ports)
+				} else {
 					resources.Services = append(resources.Services, svc)
 					if _, ok := service.Annotations[ServiceExposeAnnotationKey]; ok {
 						ingress := t.createIngress(service)
@@ -173,9 +186,43 @@ func (t Transformer) Convert(project *types.Project) (*Resources, error) {
 func validateService(service types.ServiceConfig) error {
 	if service.HealthCheck != nil && len(service.HealthCheck.Test) > 0 {
 		switch service.HealthCheck.Test[0] {
-		case "CMD-SHELL", "CMD", "NONE":
+		case "CMD-SHELL", "CMD":
+			if len(service.HealthCheck.Test) < 2 {
+				return fmt.Errorf("healthcheck test %q requires a command (the probe would be rejected by Kubernetes on apply)", service.HealthCheck.Test[0])
+			}
+		case "NONE":
 		default:
 			return fmt.Errorf("unsupported healthcheck test type %q (expected CMD, CMD-SHELL, or NONE)", service.HealthCheck.Test[0])
+		}
+	}
+	for _, port := range service.Ports {
+		if port.Published == "" {
+			continue
+		}
+		if _, err := strconv.Atoi(port.Published); err != nil {
+			return fmt.Errorf("invalid published port %q: only single numeric ports are supported", port.Published)
+		}
+	}
+	for _, e := range service.Expose {
+		target, _, _ := strings.Cut(e, "/")
+		if _, err := strconv.Atoi(target); err != nil {
+			return fmt.Errorf(`invalid expose entry %q: only "port" or "port/protocol" is supported`, e)
+		}
+	}
+	// Named users and groups resolve against the image's /etc/passwd locally
+	// but cannot be mapped to Kubernetes securityContext IDs; silently
+	// running as a different user than compose would is not acceptable.
+	if err := validateNumericUserGroup(service.User); err != nil {
+		return err
+	}
+	for _, g := range service.GroupAdd {
+		if _, err := strconv.ParseInt(g, 10, 64); err != nil {
+			return fmt.Errorf("group_add %q: only numeric group IDs are supported on Kubernetes", g)
+		}
+	}
+	for i, hook := range service.PreStart {
+		if err := validateNumericUserGroup(hook.User); err != nil {
+			return fmt.Errorf("pre_start hook %d: %w", i, err)
 		}
 	}
 	if schedule, ok := service.Annotations[CronJobScheduleAnnotationKey]; ok && schedule == "" {

--- a/convert_negative_test.go
+++ b/convert_negative_test.go
@@ -104,11 +104,8 @@ func TestConvertNegative(t *testing.T) {
 		}
 	})
 
-	t.Run("invalid published port is silently ignored", func(t *testing.T) {
+	t.Run("invalid published port returns error", func(t *testing.T) {
 		t.Parallel()
-		// Documents existing behavior at convert.go convertServicePorts.
-		// strconv errors are swallowed; published falls back to 0.
-		// TODO: surface a real error in a future PR.
 		project := projectWith(types.ServiceConfig{
 			Name:  "web",
 			Image: "nginx",
@@ -116,16 +113,22 @@ func TestConvertNegative(t *testing.T) {
 				{Target: 80, Published: "not-a-number"},
 			},
 		})
-		resources, err := kubepose.Transformer{}.Convert(project)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "invalid published port") {
+			t.Fatalf("expected invalid published port error, got: %v", err)
 		}
-		if len(resources.Services) != 1 {
-			t.Fatalf("expected 1 service, got %d", len(resources.Services))
-		}
-		ports := resources.Services[0].Spec.Ports
-		if len(ports) != 1 || ports[0].Port != 0 {
-			t.Fatalf("expected silent fallback to port 0, got %+v", ports)
+	})
+
+	t.Run("invalid expose entry returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:   "web",
+			Image:  "nginx",
+			Expose: []string{"not-a-port"},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "invalid expose entry") {
+			t.Fatalf("expected invalid expose entry error, got: %v", err)
 		}
 	})
 
@@ -177,22 +180,49 @@ func TestConvertNegative(t *testing.T) {
 		}
 	})
 
-	t.Run("named user is skipped with no security context", func(t *testing.T) {
+	t.Run("named user returns error", func(t *testing.T) {
 		t.Parallel()
-		// Documents that named users like "ubuntu" are dropped (only numeric
-		// IDs are supported); a warning is printed but conversion succeeds.
+		// Named users resolve against the image's /etc/passwd locally but
+		// have no Kubernetes securityContext equivalent, so the deployed
+		// container would silently run as a different user.
+		for _, user := range []string{"ubuntu", "1000:staff"} {
+			project := projectWith(types.ServiceConfig{
+				Name:  "web",
+				Image: "nginx",
+				User:  user,
+			})
+			_, err := kubepose.Transformer{}.Convert(project)
+			if err == nil || !strings.Contains(err.Error(), "only numeric user/group IDs") {
+				t.Fatalf("user %q: expected numeric-IDs error, got: %v", user, err)
+			}
+		}
+	})
+
+	t.Run("named group_add returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:     "web",
+			Image:    "nginx",
+			GroupAdd: []string{"docker"},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "only numeric group IDs") {
+			t.Fatalf("expected numeric group IDs error, got: %v", err)
+		}
+	})
+
+	t.Run("named pre_start hook user returns error", func(t *testing.T) {
+		t.Parallel()
 		project := projectWith(types.ServiceConfig{
 			Name:  "web",
 			Image: "nginx",
-			User:  "ubuntu",
+			PreStart: []types.ServiceHook{
+				{Command: []string{"echo", "hi"}, User: "root"},
+			},
 		})
-		resources, err := kubepose.Transformer{}.Convert(project)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		spec := resources.Deployments[0].Spec.Template.Spec
-		if spec.SecurityContext != nil {
-			t.Fatalf("expected no SecurityContext for non-numeric user, got %+v", spec.SecurityContext)
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "only numeric user/group IDs") {
+			t.Fatalf("expected numeric-IDs error for hook user, got: %v", err)
 		}
 	})
 
@@ -216,11 +246,10 @@ func TestConvertNegative(t *testing.T) {
 		}
 	})
 
-	t.Run("CMD with empty command list still produces a probe", func(t *testing.T) {
+	t.Run("CMD with empty command list returns error", func(t *testing.T) {
 		t.Parallel()
-		// Documents current behavior: ["CMD"] with no following args
-		// yields an exec probe with an empty Command slice (kubectl would
-		// reject this on apply). A future PR could reject this upfront.
+		// ["CMD"] with no following args would yield an exec probe with an
+		// empty Command slice, which Kubernetes rejects on apply.
 		project := projectWith(types.ServiceConfig{
 			Name:  "web",
 			Image: "nginx",
@@ -228,16 +257,73 @@ func TestConvertNegative(t *testing.T) {
 				Test: []string{"CMD"},
 			},
 		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "requires a command") {
+			t.Fatalf("expected empty-command healthcheck error, got: %v", err)
+		}
+	})
+
+	t.Run("group with only init services returns error", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name: "proxy", Image: "envoy",
+			Restart: "always",
+			Annotations: map[string]string{
+				kubepose.ServiceGroupAnnotationKey:  "myapp",
+				kubepose.ContainerTypeAnnotationKey: "init",
+			},
+		})
+		_, err := kubepose.Transformer{}.Convert(project)
+		if err == nil || !strings.Contains(err.Error(), "only") || !strings.Contains(err.Error(), "init") {
+			t.Fatalf("expected init-only group error, got: %v", err)
+		}
+	})
+
+	t.Run("portless service gets a headless Service for DNS parity", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:  "db",
+			Image: "postgres",
+		})
 		resources, err := kubepose.Transformer{}.Convert(project)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		c := resources.Deployments[0].Spec.Template.Spec.Containers[0]
-		if c.LivenessProbe == nil || c.LivenessProbe.Exec == nil {
-			t.Fatal("expected an exec liveness probe")
+		if len(resources.Services) != 1 {
+			t.Fatalf("expected 1 service, got %d", len(resources.Services))
 		}
-		if len(c.LivenessProbe.Exec.Command) != 0 {
-			t.Fatalf("expected empty Command, got %v", c.LivenessProbe.Exec.Command)
+		svc := resources.Services[0]
+		if svc.Spec.ClusterIP != corev1.ClusterIPNone {
+			t.Fatalf("expected headless service (ClusterIP None), got %q", svc.Spec.ClusterIP)
+		}
+		if len(svc.Spec.Ports) != 0 {
+			t.Fatalf("expected no ports, got %+v", svc.Spec.Ports)
+		}
+	})
+
+	t.Run("expose entries become Service ports", func(t *testing.T) {
+		t.Parallel()
+		project := projectWith(types.ServiceConfig{
+			Name:   "db",
+			Image:  "postgres",
+			Expose: []string{"5432", "9000/udp"},
+		})
+		resources, err := kubepose.Transformer{}.Convert(project)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		svc := resources.Services[0]
+		if svc.Spec.ClusterIP == corev1.ClusterIPNone {
+			t.Fatal("expected a regular ClusterIP service when expose ports exist")
+		}
+		if len(svc.Spec.Ports) != 2 {
+			t.Fatalf("expected 2 ports, got %+v", svc.Spec.Ports)
+		}
+		if svc.Spec.Ports[0].Port != 5432 || svc.Spec.Ports[0].Protocol != corev1.ProtocolTCP {
+			t.Fatalf("expected 5432/TCP first, got %+v", svc.Spec.Ports[0])
+		}
+		if svc.Spec.Ports[1].Port != 9000 || svc.Spec.Ports[1].Protocol != corev1.ProtocolUDP {
+			t.Fatalf("expected 9000/UDP second, got %+v", svc.Spec.Ports[1])
 		}
 	})
 

--- a/pod_spec.go
+++ b/pod_spec.go
@@ -51,8 +51,25 @@ func getRestartPolicy(service types.ServiceConfig) corev1.RestartPolicy {
 	return corev1.RestartPolicyAlways
 }
 
+// validateNumericUserGroup rejects compose "user" values ("uid" or "uid:gid")
+// that Kubernetes cannot map: a named user resolves against the image's
+// /etc/passwd locally but has no securityContext equivalent, so the deployed
+// container would silently run as a different user than compose runs it as.
+func validateNumericUserGroup(user string) error {
+	if user == "" {
+		return nil
+	}
+	for _, part := range strings.SplitN(user, ":", 2) {
+		if _, err := strconv.ParseInt(part, 10, 64); err != nil {
+			return fmt.Errorf("user %q: only numeric user/group IDs are supported on Kubernetes", user)
+		}
+	}
+	return nil
+}
+
 // parseUserGroupIDs parses a compose "user" value ("uid" or "uid:gid") into
-// numeric IDs, warning about named users/groups which Kubernetes cannot map.
+// numeric IDs. Non-numeric parts are rejected by validateNumericUserGroup
+// before conversion; the warnings here are a safety net only.
 func parseUserGroupIDs(user string) (runAsUser, runAsGroup *int64) {
 	if user == "" {
 		return nil, nil
@@ -63,14 +80,14 @@ func parseUserGroupIDs(user string) (runAsUser, runAsGroup *int64) {
 	if uid, err := strconv.ParseInt(parts[0], 10, 64); err == nil {
 		runAsUser = &uid
 	} else {
-		fmt.Printf("Warning: skipping named user %q - only numeric IDs are supported\n", parts[0])
+		logrus.Warnf("skipping named user %q - only numeric IDs are supported", parts[0])
 	}
 
 	if len(parts) > 1 {
 		if gid, err := strconv.ParseInt(parts[1], 10, 64); err == nil {
 			runAsGroup = &gid
 		} else {
-			fmt.Printf("Warning: skipping named group %q - only numeric IDs are supported\n", parts[1])
+			logrus.Warnf("skipping named group %q - only numeric IDs are supported", parts[1])
 		}
 	}
 
@@ -87,7 +104,7 @@ func getSecurityContext(service types.ServiceConfig) *corev1.PodSecurityContext 
 		if gid, err := strconv.ParseInt(g, 10, 64); err == nil {
 			supplementalGroups = append(supplementalGroups, gid)
 		} else {
-			fmt.Printf("Warning: skipping named group %q - only numeric IDs are supported\n", g)
+			logrus.Warnf("skipping named group %q - only numeric IDs are supported", g)
 		}
 	}
 

--- a/services.go
+++ b/services.go
@@ -14,6 +14,18 @@ import (
 // TODO support LoadBalancer, NodePort, ExternalName, ClusterIP types via annotations.
 func (t Transformer) createService(service types.ServiceConfig) *corev1.Service {
 	serviceName := getServiceName(service)
+	ports := appendExposePorts(convertServicePorts(service.Ports), service.Expose)
+	spec := corev1.ServiceSpec{
+		Selector: map[string]string{
+			AppSelectorLabelKey: serviceName,
+		},
+		Ports: ports,
+	}
+	if len(ports) == 0 {
+		// Compose gives every service a DNS name whether or not it publishes
+		// ports. A headless Service keeps that contract on Kubernetes.
+		spec.ClusterIP = corev1.ClusterIPNone
+	}
 	return &corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -24,12 +36,53 @@ func (t Transformer) createService(service types.ServiceConfig) *corev1.Service 
 			Annotations: mergeMaps(service.Annotations, t.Annotations),
 			Labels:      mergeMaps(service.Labels, t.Labels),
 		},
-		Spec: corev1.ServiceSpec{
-			Selector: map[string]string{
-				AppSelectorLabelKey: serviceName,
-			},
-			Ports: convertServicePorts(service.Ports),
-		},
+		Spec: spec,
+	}
+}
+
+// appendExposePorts adds compose expose entries ("port" or "port/protocol")
+// as Service ports, skipping targets already covered by published ports.
+// Entries are validated in validateService, so parse failures are skipped.
+func appendExposePorts(ports []corev1.ServicePort, expose []string) []corev1.ServicePort {
+	seen := make(map[int]bool)
+	for _, p := range ports {
+		seen[p.TargetPort.IntValue()] = true
+	}
+	for _, e := range expose {
+		target, protocol, _ := strings.Cut(e, "/")
+		n, err := strconv.Atoi(target)
+		if err != nil || seen[n] {
+			continue
+		}
+		seen[n] = true
+		ports = append(ports, corev1.ServicePort{
+			Name:       strconv.Itoa(n),
+			Port:       int32(n),
+			TargetPort: intstr.FromInt(n),
+			Protocol:   convertProtocol(protocol),
+		})
+	}
+	return ports
+}
+
+// mergeServicePorts folds another group member's ports into an existing
+// Service, so port declarations survive regardless of which member was
+// converted first. A headless placeholder becomes a normal ClusterIP Service
+// once any member contributes ports.
+func mergeServicePorts(existing *corev1.Service, ports []corev1.ServicePort) {
+	seen := make(map[int32]bool)
+	for _, p := range existing.Spec.Ports {
+		seen[p.Port] = true
+	}
+	for _, p := range ports {
+		if seen[p.Port] {
+			continue
+		}
+		seen[p.Port] = true
+		existing.Spec.Ports = append(existing.Spec.Ports, p)
+	}
+	if len(existing.Spec.Ports) > 0 {
+		existing.Spec.ClusterIP = ""
 	}
 }
 
@@ -103,6 +156,22 @@ func (t Transformer) createIngress(service types.ServiceConfig) *networkingv1.In
 			servicePort = published
 			break
 		}
+	}
+	if servicePort == 0 {
+		for _, e := range service.Expose {
+			target, protocol, _ := strings.Cut(e, "/")
+			if protocol != "" && !strings.EqualFold(protocol, "tcp") {
+				continue
+			}
+			if p, err := strconv.Atoi(target); err == nil {
+				servicePort = int32(p)
+				break
+			}
+		}
+	}
+	if servicePort == 0 {
+		// A portless service has nothing an Ingress could route to.
+		return nil
 	}
 
 	var rules []networkingv1.IngressRule

--- a/testdata/TestConvert/configs/k8s.yaml
+++ b/testdata/TestConvert/configs/k8s.yaml
@@ -89,3 +89,15 @@ spec:
           name: env_config-290a46c2
         name: env_config
 status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: app
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/group/k8s.yaml
+++ b/testdata/TestConvert/group/k8s.yaml
@@ -61,3 +61,22 @@ metadata:
     kubepose.secret.hmacKey: kubepose.secret.v1
   name: secret-79f7063e
 type: Opaque
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubepose.container.type: app
+    kubepose.service.group: myapp
+  name: myapp
+spec:
+  ports:
+  - name: "8080"
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: myapp
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/hostpath/k8s.yaml
+++ b/testdata/TestConvert/hostpath/k8s.yaml
@@ -37,3 +37,15 @@ spec:
           path: /host/tmp
         name: logs-default
 status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: test
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: test
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/hpa/k8s.yaml
+++ b/testdata/TestConvert/hpa/k8s.yaml
@@ -136,3 +136,45 @@ spec:
 status:
   currentMetrics: null
   desiredReplicas: 0
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubepose.hpa.cpu: "70"
+    kubepose.hpa.maxReplicas: "6"
+    kubepose.hpa.minReplicas: "2"
+  name: api
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: api
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kubepose.hpa.maxReplicas: "10"
+  name: web
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: web
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: worker
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: worker
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/interpolation/k8s.yaml
+++ b/testdata/TestConvert/interpolation/k8s.yaml
@@ -126,3 +126,58 @@ spec:
         resources: {}
       restartPolicy: Always
 status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    gcr.io/google-containers/: BAR
+  name: bar
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: bar
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    foo1: gcr.io/google-containers/
+    foo2: gcr.io/google-containers/
+    foo3: default
+    foo4: gcr.io/google-containers/
+  name: foo
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: foo
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rep
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: rep
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: web
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/pre-start/k8s.yaml
+++ b/testdata/TestConvert/pre-start/k8s.yaml
@@ -102,3 +102,15 @@ spec:
     resources: {}
   restartPolicy: Never
 status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: web
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/stop-grace-period/k8s.yaml
+++ b/testdata/TestConvert/stop-grace-period/k8s.yaml
@@ -68,3 +68,39 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 300
 status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: fast-worker
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: fast-worker
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: immediate
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: immediate
+status:
+  loadBalancer: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: worker
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: worker
+status:
+  loadBalancer: {}

--- a/testdata/TestConvert/user/k8s.yaml
+++ b/testdata/TestConvert/user/k8s.yaml
@@ -24,4 +24,18 @@ spec:
         fsGroup: 1000
         runAsGroup: 1000
         runAsUser: 1000
+        supplementalGroups:
+        - 999
 status: {}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: app
+spec:
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: app
+status:
+  loadBalancer: {}

--- a/testdata/group/compose.yaml
+++ b/testdata/group/compose.yaml
@@ -21,9 +21,12 @@ services:
     secrets:
       - secret
 
-  # Another app container
+  # Another app container; expose gives the group Service a port without
+  # publishing it on the host
   api:
     image: nginx
+    expose:
+      - "8080"
     annotations:
       kubepose.service.group: "myapp"
       kubepose.container.type: "app" # optional, this is default

--- a/testdata/user/compose.yaml
+++ b/testdata/user/compose.yaml
@@ -2,8 +2,8 @@ services:
   app:
     image: alpine
     command: id
-    user: "1000:1000" # Run as specific user:group
-    group_add: # Add additional groups
-      - docker
+    user: "1000:1000" # Run as specific user:group (numeric IDs only)
+    group_add: # Add additional groups (numeric IDs only)
+      - "999"
     security_opt: # Security options
       - no-new-privileges


### PR DESCRIPTION
## Summary

Stacked on #131. Applies the guiding principle that the deployed environment should behave like local compose, with annotations as the only sanctioned deviations — by closing the places where conversion silently diverged.

### Service discovery parity

- **Every long-running service now gets a Kubernetes Service**, so services resolve by name in the cluster like they do on the compose network. Compose `expose` entries (`"port"` or `"port/protocol"`) become Service ports — compose `ports:` is about host publishing, `expose`/plain reachability never required it locally. A service with neither gets a **headless Service** (DNS, no VIP). CronJob services are excluded unless they declare ports, since their pods are short-lived.
- Group members **merge their ports into the shared Service** regardless of conversion order (previously the first member to convert won; now a portless member can no longer mask a later member's ports).
- Ingress creation falls back to the first TCP `expose` port and is skipped for fully portless services.

### Errors instead of silent divergence

- A group containing **only init (sidecar) services** errors instead of silently emitting nothing.
- **Invalid published ports and expose entries** error instead of silently falling back to port 0.
- **Named users/groups** (`user`, `group_add`, `pre_start` hook `user`) error: they resolve against the image's `/etc/passwd` locally but have no `securityContext` equivalent, so the deployed container would silently run as a different user than compose runs it as. The residual safety-net warnings moved from stdout to logrus/stderr so they can't corrupt piped manifests.
- A `healthcheck` of `["CMD"]` with no command errors instead of emitting a probe Kubernetes rejects on apply.

## Breaking changes

- Portless services now emit a headless Service (new resource in output).
- Named users/groups, invalid published/expose ports, empty `CMD` healthchecks, and init-only groups are now conversion errors instead of silent fallbacks.

## Test plan

- `go vet`, `gofmt`, `go test -short ./...` clean; changed fixtures validate under `docker compose config`.
- Negative tests flipped from documenting silent fallbacks to asserting errors; new tests for headless Services, expose-port mapping, group port merging inputs, and each new validation.
- Golden files regenerated — all diffs are pure additions (headless/expose Services, `supplementalGroups` from the now-numeric `group_add` fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DtLcwVcWTnwPcSPU1rn9Jm

---
_Generated by [Claude Code](https://claude.ai/code/session_01DtLcwVcWTnwPcSPU1rn9Jm)_